### PR TITLE
Add support for downloading source artifacts from Github release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Fetches and creates versioned GitHub resources.
 
 * `repository`: *Required.* The repository name that contains the releases.
 
-* `access_token`: *Optional.* Used for accessing a release in a private-repo 
+* `access_token`: *Optional.* Used for accessing a release in a private-repo
    during an `in` and pushing a release to a repo during an `out`. The access
    token you create is only required to have the `repo` or `public_repo` scope.
 
@@ -66,6 +66,12 @@ Also creates the following files:
 
 * `globs`: *Optional.* A list of globs for files that will be downloaded from
   the release. If not specified, all assets will be fetched.
+
+* `include_source_tarball`: *Optional.* Enables downloading of the source
+  artifact tarball for the release as `source.tar.gz`. Defaults to `false`.
+
+* `include_source_zip`: *Optional.* Enables downloading of the source
+  artifact zip for the release as `source.zip`. Defaults to `false`.
 
 ### `out`: Publish a release.
 

--- a/fakes/fake_git_hub.go
+++ b/fakes/fake_git_hub.go
@@ -3,6 +3,7 @@ package fakes
 
 import (
 	"io"
+	"net/url"
 	"os"
 	"sync"
 
@@ -79,6 +80,24 @@ type FakeGitHub struct {
 	}
 	downloadReleaseAssetReturns struct {
 		result1 io.ReadCloser
+		result2 error
+	}
+	GetTarballLinkStub        func(tag string) (*url.URL, error)
+	getTarballLinkMutex       sync.RWMutex
+	getTarballLinkArgsForCall []struct {
+		tag string
+	}
+	getTarballLinkReturns struct {
+		result1 *url.URL
+		result2 error
+	}
+	GetZipballLinkStub        func(tag string) (*url.URL, error)
+	getZipballLinkMutex       sync.RWMutex
+	getZipballLinkArgsForCall []struct {
+		tag string
+	}
+	getZipballLinkReturns struct {
+		result1 *url.URL
 		result2 error
 	}
 }
@@ -335,6 +354,72 @@ func (fake *FakeGitHub) DownloadReleaseAssetReturns(result1 io.ReadCloser, resul
 	fake.DownloadReleaseAssetStub = nil
 	fake.downloadReleaseAssetReturns = struct {
 		result1 io.ReadCloser
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeGitHub) GetTarballLink(tag string) (*url.URL, error) {
+	fake.getTarballLinkMutex.Lock()
+	fake.getTarballLinkArgsForCall = append(fake.getTarballLinkArgsForCall, struct {
+		tag string
+	}{tag})
+	fake.getTarballLinkMutex.Unlock()
+	if fake.GetReleaseByTagStub != nil {
+		return fake.GetTarballLinkStub(tag)
+	} else {
+		return fake.getTarballLinkReturns.result1, fake.getTarballLinkReturns.result2
+	}
+}
+
+func (fake *FakeGitHub) GetTarballLinkCallCount() int {
+	fake.getTarballLinkMutex.RLock()
+	defer fake.getTarballLinkMutex.RUnlock()
+	return len(fake.getTarballLinkArgsForCall)
+}
+
+func (fake *FakeGitHub) GetTarballLinkArgsForCall(i int) string {
+	fake.getTarballLinkMutex.RLock()
+	defer fake.getTarballLinkMutex.RUnlock()
+	return fake.getTarballLinkArgsForCall[i].tag
+}
+
+func (fake *FakeGitHub) GetTarballLinkReturns(result1 *url.URL, result2 error) {
+	fake.GetTarballLinkStub = nil
+	fake.getTarballLinkReturns = struct {
+		result1 *url.URL
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeGitHub) GetZipballLink(tag string) (*url.URL, error) {
+	fake.getZipballLinkMutex.Lock()
+	fake.getZipballLinkArgsForCall = append(fake.getZipballLinkArgsForCall, struct {
+		tag string
+	}{tag})
+	fake.getZipballLinkMutex.Unlock()
+	if fake.GetReleaseByTagStub != nil {
+		return fake.GetZipballLinkStub(tag)
+	} else {
+		return fake.getZipballLinkReturns.result1, fake.getZipballLinkReturns.result2
+	}
+}
+
+func (fake *FakeGitHub) GetZipballLinkCallCount() int {
+	fake.getZipballLinkMutex.RLock()
+	defer fake.getZipballLinkMutex.RUnlock()
+	return len(fake.getZipballLinkArgsForCall)
+}
+
+func (fake *FakeGitHub) GetZipballLinkArgsForCall(i int) string {
+	fake.getZipballLinkMutex.RLock()
+	defer fake.getZipballLinkMutex.RUnlock()
+	return fake.getZipballLinkArgsForCall[i].tag
+}
+
+func (fake *FakeGitHub) GetZipballLinkReturns(result1 *url.URL, result2 error) {
+	fake.GetZipballLinkStub = nil
+	fake.getZipballLinkReturns = struct {
+		result1 *url.URL
 		result2 error
 	}{result1, result2}
 }

--- a/github.go
+++ b/github.go
@@ -23,6 +23,9 @@ type GitHub interface {
 	UploadReleaseAsset(release github.RepositoryRelease, name string, file *os.File) error
 	DeleteReleaseAsset(asset github.ReleaseAsset) error
 	DownloadReleaseAsset(asset github.ReleaseAsset) (io.ReadCloser, error)
+
+	GetTarballLink(tag string) (*url.URL, error)
+	GetZipballLink(tag string) (*url.URL, error)
 }
 
 type GitHubClient struct {
@@ -169,4 +172,24 @@ func (g *GitHubClient) DownloadReleaseAsset(asset github.ReleaseAsset) (io.ReadC
 	}
 
 	return res, err
+}
+
+func (g *GitHubClient) GetTarballLink(tag string) (*url.URL, error) {
+	opt := &github.RepositoryContentGetOptions{Ref: tag}
+	u, res, err := g.client.Repositories.GetArchiveLink(g.user, g.repository, github.Tarball, opt)
+	if err != nil {
+		return nil, err
+	}
+	res.Body.Close()
+	return u, nil
+}
+
+func (g *GitHubClient) GetZipballLink(tag string) (*url.URL, error) {
+	opt := &github.RepositoryContentGetOptions{Ref: tag}
+	u, res, err := g.client.Repositories.GetArchiveLink(g.user, g.repository, github.Zipball, opt)
+	if err != nil {
+		return nil, err
+	}
+	res.Body.Close()
+	return u, nil
 }

--- a/resources.go
+++ b/resources.go
@@ -20,7 +20,9 @@ type InRequest struct {
 }
 
 type InParams struct {
-	Globs []string `json:"globs"`
+	Globs                []string `json:"globs"`
+	IncludeSourceTarball bool     `json:"include_source_tarball"`
+	IncludeSourceZip     bool     `json:"include_source_zip"`
 }
 
 type InResponse struct {


### PR DESCRIPTION
This adds support for retrieving the tarball or zip source artifact from a
Github release. This is done through defining a
"params.include_source_tarball" or "params.include_source_zip" boolean setting.

With this, the resource will download the respective source artfact into the
target directory as either "source.tar.gz" or "source.zip".

Fixes #13 