### PR TITLE
filter by drafts in the `check` step

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Fetches and creates versioned GitHub resources.
 * `github_api_url`: *Optional.* If you use a non-public GitHub deployment then
   you can set your API URL here.
 
+* `drafts`: *Optional.* When set to `true` only returns draft releases with
+  semver compliant tags. Defaults to `false` returning only final releases
+  with semver compliant tags.
+
 ### Example
 
 ``` yaml
@@ -93,3 +97,5 @@ matching the patterns in `globs` to the release.
 
 * `globs`: *Optional.* A list of globs for files that will be uploaded alongside
   the created release.
+
+* `draft`: *Optional.* A boolean to set the release in draft mode or not.

--- a/fakes/fake_git_hub.go
+++ b/fakes/fake_git_hub.go
@@ -15,7 +15,7 @@ type FakeGitHub struct {
 	ListReleasesStub        func() ([]github.RepositoryRelease, error)
 	listReleasesMutex       sync.RWMutex
 	listReleasesArgsForCall []struct{}
-	listReleasesReturns     struct {
+	listReleasesReturns struct {
 		result1 []github.RepositoryRelease
 		result2 error
 	}
@@ -25,6 +25,15 @@ type FakeGitHub struct {
 		tag string
 	}
 	getReleaseByTagReturns struct {
+		result1 *github.RepositoryRelease
+		result2 error
+	}
+	GetReleaseStub        func(id int) (*github.RepositoryRelease, error)
+	getReleaseMutex       sync.RWMutex
+	getReleaseArgsForCall []struct {
+		id int
+	}
+	getReleaseReturns struct {
 		result1 *github.RepositoryRelease
 		result2 error
 	}
@@ -155,6 +164,39 @@ func (fake *FakeGitHub) GetReleaseByTagArgsForCall(i int) string {
 func (fake *FakeGitHub) GetReleaseByTagReturns(result1 *github.RepositoryRelease, result2 error) {
 	fake.GetReleaseByTagStub = nil
 	fake.getReleaseByTagReturns = struct {
+		result1 *github.RepositoryRelease
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeGitHub) GetRelease(id int) (*github.RepositoryRelease, error) {
+	fake.getReleaseMutex.Lock()
+	fake.getReleaseArgsForCall = append(fake.getReleaseArgsForCall, struct {
+		id int
+	}{id})
+	fake.getReleaseMutex.Unlock()
+	if fake.GetReleaseStub != nil {
+		return fake.GetReleaseStub(id)
+	} else {
+		return fake.getReleaseReturns.result1, fake.getReleaseReturns.result2
+	}
+}
+
+func (fake *FakeGitHub) GetReleaseCallCount() int {
+	fake.getReleaseMutex.RLock()
+	defer fake.getReleaseMutex.RUnlock()
+	return len(fake.getReleaseArgsForCall)
+}
+
+func (fake *FakeGitHub) GetReleaseArgsForCall(i int) int {
+	fake.getReleaseMutex.RLock()
+	defer fake.getReleaseMutex.RUnlock()
+	return fake.getReleaseArgsForCall[i].id
+}
+
+func (fake *FakeGitHub) GetReleaseReturns(result1 *github.RepositoryRelease, result2 error) {
+	fake.GetReleaseStub = nil
+	fake.getReleaseReturns = struct {
 		result1 *github.RepositoryRelease
 		result2 error
 	}{result1, result2}
@@ -364,7 +406,7 @@ func (fake *FakeGitHub) GetTarballLink(tag string) (*url.URL, error) {
 		tag string
 	}{tag})
 	fake.getTarballLinkMutex.Unlock()
-	if fake.GetReleaseByTagStub != nil {
+	if fake.GetTarballLinkStub != nil {
 		return fake.GetTarballLinkStub(tag)
 	} else {
 		return fake.getTarballLinkReturns.result1, fake.getTarballLinkReturns.result2
@@ -397,7 +439,7 @@ func (fake *FakeGitHub) GetZipballLink(tag string) (*url.URL, error) {
 		tag string
 	}{tag})
 	fake.getZipballLinkMutex.Unlock()
-	if fake.GetReleaseByTagStub != nil {
+	if fake.GetZipballLinkStub != nil {
 		return fake.GetZipballLinkStub(tag)
 	} else {
 		return fake.getZipballLinkReturns.result1, fake.getZipballLinkReturns.result2

--- a/github.go
+++ b/github.go
@@ -16,6 +16,7 @@ import (
 type GitHub interface {
 	ListReleases() ([]github.RepositoryRelease, error)
 	GetReleaseByTag(tag string) (*github.RepositoryRelease, error)
+	GetRelease(id int) (*github.RepositoryRelease, error)
 	CreateRelease(release github.RepositoryRelease) (*github.RepositoryRelease, error)
 	UpdateRelease(release github.RepositoryRelease) (*github.RepositoryRelease, error)
 
@@ -81,6 +82,20 @@ func (g *GitHubClient) ListReleases() ([]github.RepositoryRelease, error) {
 
 func (g *GitHubClient) GetReleaseByTag(tag string) (*github.RepositoryRelease, error) {
 	release, res, err := g.client.Repositories.GetReleaseByTag(g.user, g.repository, tag)
+	if err != nil {
+		return &github.RepositoryRelease{}, nil
+	}
+
+	err = res.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return release, nil
+}
+
+func (g *GitHubClient) GetRelease(id int) (*github.RepositoryRelease, error) {
+	release, res, err := g.client.Repositories.GetRelease(g.user, g.repository, id)
 	if err != nil {
 		return &github.RepositoryRelease{}, nil
 	}

--- a/metadata.go
+++ b/metadata.go
@@ -33,5 +33,19 @@ func metadataFromRelease(release *github.RepositoryRelease) []MetadataPair {
 		})
 	}
 
+	if release.TagName != nil {
+		metadata = append(metadata, MetadataPair{
+			Name:  "tag",
+			Value: *release.TagName,
+		})
+	}
+
+	if *release.Draft {
+		metadata = append(metadata, MetadataPair{
+			Name:  "draft",
+			Value: "true",
+		})
+	}
+
 	return metadata
 }

--- a/out_command.go
+++ b/out_command.go
@@ -69,7 +69,7 @@ func (c *OutCommand) Run(sourceDir string, request OutRequest) (OutResponse, err
 
 	var existingRelease *github.RepositoryRelease
 	for _, e := range existingReleases {
-		if *e.TagName == tag {
+		if e.TagName != nil && *e.TagName == tag {
 			existingRelease = &e
 			break
 		}
@@ -130,9 +130,7 @@ func (c *OutCommand) Run(sourceDir string, request OutRequest) (OutResponse, err
 	}
 
 	return OutResponse{
-		Version: Version{
-			Tag: tag,
-		},
+		Version:  versionFromDraft(release),
 		Metadata: metadataFromRelease(release),
 	}, nil
 }

--- a/out_command_test.go
+++ b/out_command_test.go
@@ -77,9 +77,14 @@ var _ = Describe("Out Command", func() {
 		BeforeEach(func() {
 			githubClient.ListReleasesReturns([]github.RepositoryRelease{
 				{
+					ID:    github.Int(1),
+					Draft: github.Bool(true),
+				},
+				{
 					ID:      github.Int(112),
 					TagName: github.String("some-tag-name"),
 					Assets:  existingAssets,
+					Draft:   github.Bool(false),
 				},
 			}, nil)
 
@@ -228,6 +233,19 @@ var _ = Describe("Out Command", func() {
 				Ω(*release.Body).Should(Equal(""))
 				Ω(*release.Draft).Should(Equal(true))
 			})
+
+			It("has some sweet metadata", func() {
+				outResponse, err := command.Run(sourcesDir, request)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Ω(outResponse.Metadata).Should(ConsistOf(
+					resource.MetadataPair{Name: "url", Value: "http://google.com"},
+					resource.MetadataPair{Name: "name", Value: "release-name", URL: "http://google.com"},
+					resource.MetadataPair{Name: "body", Value: "*markdown*", Markdown: true},
+					resource.MetadataPair{Name: "tag", Value: "0.3.12"},
+					resource.MetadataPair{Name: "draft", Value: "true"},
+				))
+			})
 		})
 
 		Context("with file globs", func() {
@@ -272,6 +290,7 @@ var _ = Describe("Out Command", func() {
 					resource.MetadataPair{Name: "url", Value: "http://google.com"},
 					resource.MetadataPair{Name: "name", Value: "release-name", URL: "http://google.com"},
 					resource.MetadataPair{Name: "body", Value: "*markdown*", Markdown: true},
+					resource.MetadataPair{Name: "tag", Value: "0.3.12"},
 				))
 			})
 

--- a/resource_suite_test.go
+++ b/resource_suite_test.go
@@ -13,18 +13,25 @@ func TestGithubReleaseResource(t *testing.T) {
 	RunSpecs(t, "Github Release Resource Suite")
 }
 
-func newRepositoryRelease(version string) github.RepositoryRelease {
-	draft := false
+func newRepositoryRelease(id int, version string) github.RepositoryRelease {
 	return github.RepositoryRelease{
 		TagName: github.String(version),
-		Draft:   &draft,
+		Draft:   github.Bool(false),
+		ID:      github.Int(id),
 	}
 }
 
-func newDraftRepositoryRelease(version string) github.RepositoryRelease {
-	draft := true
+func newDraftRepositoryRelease(id int, version string) github.RepositoryRelease {
 	return github.RepositoryRelease{
 		TagName: github.String(version),
-		Draft:   &draft,
+		Draft:   github.Bool(true),
+		ID:      github.Int(id),
+	}
+}
+
+func newDraftWithNilTagRepositoryRelease(id int) github.RepositoryRelease {
+	return github.RepositoryRelease{
+		Draft: github.Bool(true),
+		ID:    github.Int(id),
 	}
 }

--- a/resources.go
+++ b/resources.go
@@ -6,6 +6,7 @@ type Source struct {
 
 	GitHubAPIURL string `json:"github_api_url"`
 	AccessToken  string `json:"access_token"`
+	Drafts       bool   `json:"drafts"`
 }
 
 type CheckRequest struct {
@@ -51,7 +52,8 @@ type OutResponse struct {
 }
 
 type Version struct {
-	Tag string `json:"tag"`
+	Tag string `json:"tag,omitempty"`
+	ID  string `json:"id,omitempty"`
 }
 
 type MetadataPair struct {

--- a/versions.go
+++ b/versions.go
@@ -1,10 +1,27 @@
 package resource
 
-import "regexp"
+import (
+	"regexp"
+	"strconv"
+
+	"github.com/zachgersh/go-github/github"
+)
 
 // determineVersionFromTag converts git tags v1.2.3 into semver 1.2.3 values
 func determineVersionFromTag(tag string) string {
 	re := regexp.MustCompile("v?([^v].*)")
 	matches := re.FindStringSubmatch(tag)
-	return matches[1]
+	if len(matches) > 0 {
+		return matches[1]
+	} else {
+		return ""
+	}
+}
+
+func versionFromDraft(release *github.RepositoryRelease) Version {
+	if *release.Draft {
+		return Version{ID: strconv.Itoa(*release.ID)}
+	} else {
+		return Version{Tag: *release.TagName}
+	}
 }


### PR DESCRIPTION
The user now opts-in to getting final or draft releases. Default
behaviour is final releases.

NOTE: There is also strict filtering on only allowing semver supported tags.

Signed-off-by: David Jahn <david.a.jahn@gmail.com>