### PR TITLE
Fix assignment mismatch due to an API change in github.DownloadReleas…

### DIFF
--- a/github.go
+++ b/github.go
@@ -194,7 +194,7 @@ func (g *GitHubClient) DeleteReleaseAsset(asset github.ReleaseAsset) error {
 }
 
 func (g *GitHubClient) DownloadReleaseAsset(asset github.ReleaseAsset) (io.ReadCloser, error) {
-	res, err := g.client.Repositories.DownloadReleaseAsset(g.user, g.repository, *asset.ID)
+	res, _, err := g.client.Repositories.DownloadReleaseAsset(g.user, g.repository, *asset.ID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes assignment mismatch due to an API change in github.DownloadReleaseAsset() introduced by google/go-github@a4d01b49cb5a7638d42d7f3648a30621936b85d8.