### PR TITLE
Make initial version configurable at source level

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Fetches and creates versioned GitHub resources.
   will be detected and published. Note that releases must have semver compliant
   tags to be detected, even if they're drafts.
 
+* `version`: *Optional* If specified, will check all releases from the specified version to latest. Otherwise, will check only the latest release.
+
 ### Example
 
 ``` yaml
@@ -48,6 +50,16 @@ Fetches and creates versioned GitHub resources.
     user: concourse
     repository: concourse
     access_token: abcdef1234567890
+```
+
+``` yaml
+- name: gh-release
+  type: github-release
+  source:
+    user: concourse
+    repository: concourse
+    access_token: abcdef1234567890
+    version: { tag: 'v0.0.1' }
 ```
 
 ``` yaml

--- a/check_command.go
+++ b/check_command.go
@@ -60,13 +60,13 @@ func (c *CheckCommand) Run(request CheckRequest) ([]Version, error) {
 	}
 	latestRelease := filteredReleases[len(filteredReleases)-1]
 
-	if (request.Version == Version{}) {
+	if (request.Source.Version == Version{}) {
 		return []Version{
 			versionFromRelease(latestRelease),
 		}, nil
 	}
 
-	if *latestRelease.TagName == request.Version.Tag {
+	if *latestRelease.TagName == request.Source.Version.Tag {
 		return []Version{}, nil
 	}
 
@@ -77,10 +77,10 @@ func (c *CheckCommand) Run(request CheckRequest) ([]Version, error) {
 		if !upToLatest {
 			if *release.Draft || *release.Prerelease {
 				id := *release.ID
-				upToLatest = request.Version.ID == strconv.Itoa(id)
+				upToLatest = request.Source.Version.ID == strconv.Itoa(id)
 			} else {
 				version := *release.TagName
-				upToLatest = request.Version.Tag == version
+				upToLatest = request.Source.Version.Tag == version
 			}
 		}
 

--- a/check_command_test.go
+++ b/check_command_test.go
@@ -107,8 +107,10 @@ var _ = Describe("Check Command", func() {
 					command := resource.NewCheckCommand(githubClient)
 
 					response, err := command.Run(resource.CheckRequest{
-						Version: resource.Version{
-							Tag: "0.4.0",
+						Source: resource.Source{
+							Version: resource.Version{
+								Tag: "0.4.0",
+							},
 						},
 					})
 					Ω(err).ShouldNot(HaveOccurred())
@@ -120,8 +122,10 @@ var _ = Describe("Check Command", func() {
 					command := resource.NewCheckCommand(githubClient)
 
 					response, err := command.Run(resource.CheckRequest{
-						Version: resource.Version{
-							Tag: "v0.1.3",
+						Source: resource.Source{
+							Version: resource.Version{
+								Tag: "v0.1.3",
+							},
 						},
 					})
 					Ω(err).ShouldNot(HaveOccurred())
@@ -137,8 +141,10 @@ var _ = Describe("Check Command", func() {
 					command := resource.NewCheckCommand(githubClient)
 
 					response, err := command.Run(resource.CheckRequest{
-						Version: resource.Version{
-							Tag: "v3.4.5",
+						Source: resource.Source{
+							Version: resource.Version{
+								Tag: "v3.4.5",
+							},
 						},
 					})
 					Ω(err).ShouldNot(HaveOccurred())
@@ -158,8 +164,10 @@ var _ = Describe("Check Command", func() {
 						command := resource.NewCheckCommand(githubClient)
 
 						response, err := command.Run(resource.CheckRequest{
-							Version: resource.Version{
-								Tag: "v0.1.3",
+							Source: resource.Source{
+								Version: resource.Version{
+									Tag: "v0.1.3",
+								},
 							},
 						})
 						Ω(err).ShouldNot(HaveOccurred())
@@ -187,8 +195,10 @@ var _ = Describe("Check Command", func() {
 					command := resource.NewCheckCommand(githubClient)
 
 					response, err := command.Run(resource.CheckRequest{
-						Version: resource.Version{
-							Tag: "v0.1.3",
+						Source: resource.Source{
+							Version: resource.Version{
+								Tag: "v0.1.3",
+							},
 						},
 					})
 					Ω(err).ShouldNot(HaveOccurred())
@@ -217,8 +227,12 @@ var _ = Describe("Check Command", func() {
 						command := resource.NewCheckCommand(githubClient)
 
 						response, err := command.Run(resource.CheckRequest{
-							Version: resource.Version{ID: "2"},
-							Source:  resource.Source{Drafts: false, PreRelease: true, Release: false},
+							Source: resource.Source{
+								Drafts:     false,
+								PreRelease: true,
+								Release:    false,
+								Version:    resource.Version{ID: "2"},
+							},
 						})
 						Ω(err).ShouldNot(HaveOccurred())
 
@@ -232,8 +246,7 @@ var _ = Describe("Check Command", func() {
 						command := resource.NewCheckCommand(githubClient)
 
 						response, err := command.Run(resource.CheckRequest{
-							Version: resource.Version{ID: "5"},
-							Source:  resource.Source{Drafts: false, PreRelease: true, Release: false},
+							Source: resource.Source{Drafts: false, PreRelease: true, Release: false, Version: resource.Version{ID: "5"}},
 						})
 						Ω(err).ShouldNot(HaveOccurred())
 
@@ -264,8 +277,7 @@ var _ = Describe("Check Command", func() {
 						command := resource.NewCheckCommand(githubClient)
 
 						response, err := command.Run(resource.CheckRequest{
-							Version: resource.Version{Tag: "0.4.0"},
-							Source:  resource.Source{Drafts: false, PreRelease: true, Release: true},
+							Source: resource.Source{Drafts: false, PreRelease: true, Release: true, Version: resource.Version{Tag: "0.4.0"}},
 						})
 						Ω(err).ShouldNot(HaveOccurred())
 
@@ -282,8 +294,7 @@ var _ = Describe("Check Command", func() {
 						command := resource.NewCheckCommand(githubClient)
 
 						response, err := command.Run(resource.CheckRequest{
-							Version: resource.Version{ID: "5"},
-							Source:  resource.Source{Drafts: false, PreRelease: true, Release: true},
+							Source: resource.Source{Drafts: false, PreRelease: true, Release: true, Version: resource.Version{ID: "5"}},
 						})
 						Ω(err).ShouldNot(HaveOccurred())
 
@@ -312,8 +323,7 @@ var _ = Describe("Check Command", func() {
 						command := resource.NewCheckCommand(githubClient)
 
 						response, err := command.Run(resource.CheckRequest{
-							Version: resource.Version{Tag: "0.4.0"},
-							Source:  resource.Source{Drafts: false, PreRelease: true, Release: true},
+							Source: resource.Source{Drafts: false, PreRelease: true, Version: resource.Version{Tag: "0.4.0"}, Release: true},
 						})
 						Ω(err).ShouldNot(HaveOccurred())
 
@@ -331,8 +341,7 @@ var _ = Describe("Check Command", func() {
 						command := resource.NewCheckCommand(githubClient)
 
 						response, err := command.Run(resource.CheckRequest{
-							Version: resource.Version{ID: "5"},
-							Source:  resource.Source{Drafts: false, PreRelease: true, Release: true},
+							Source: resource.Source{Drafts: false, PreRelease: true, Version: resource.Version{ID: "5"}, Release: true},
 						})
 						Ω(err).ShouldNot(HaveOccurred())
 
@@ -359,8 +368,7 @@ var _ = Describe("Check Command", func() {
 						command := resource.NewCheckCommand(githubClient)
 
 						response, err := command.Run(resource.CheckRequest{
-							Version: resource.Version{ID: "2"},
-							Source:  resource.Source{Drafts: true},
+							Source: resource.Source{Version: resource.Version{ID: "2"}, Drafts: true},
 						})
 						Ω(err).ShouldNot(HaveOccurred())
 
@@ -374,8 +382,7 @@ var _ = Describe("Check Command", func() {
 						command := resource.NewCheckCommand(githubClient)
 
 						response, err := command.Run(resource.CheckRequest{
-							Version: resource.Version{ID: "5"},
-							Source:  resource.Source{Drafts: true},
+							Source: resource.Source{Version: resource.Version{ID: "5"}, Drafts: true},
 						})
 						Ω(err).ShouldNot(HaveOccurred())
 
@@ -397,8 +404,7 @@ var _ = Describe("Check Command", func() {
 						command := resource.NewCheckCommand(githubClient)
 
 						response, err := command.Run(resource.CheckRequest{
-							Version: resource.Version{},
-							Source:  resource.Source{Drafts: true},
+							Source: resource.Source{Version: resource.Version{}, Drafts: true},
 						})
 						Ω(err).ShouldNot(HaveOccurred())
 
@@ -420,8 +426,7 @@ var _ = Describe("Check Command", func() {
 						command := resource.NewCheckCommand(githubClient)
 
 						response, err := command.Run(resource.CheckRequest{
-							Version: resource.Version{},
-							Source:  resource.Source{Drafts: true, PreRelease: false},
+							Source: resource.Source{Version: resource.Version{}, Drafts: true, PreRelease: false},
 						})
 						Ω(err).ShouldNot(HaveOccurred())
 

--- a/resources.go
+++ b/resources.go
@@ -4,17 +4,17 @@ type Source struct {
 	User       string `json:"user"`
 	Repository string `json:"repository"`
 
-	GitHubAPIURL     string `json:"github_api_url"`
-	GitHubUploadsURL string `json:"github_uploads_url"`
-	AccessToken      string `json:"access_token"`
-	Drafts           bool   `json:"drafts"`
-	PreRelease       bool   `json:"pre_release"`
-	Release          bool   `json:"release"`
+	GitHubAPIURL     string  `json:"github_api_url"`
+	GitHubUploadsURL string  `json:"github_uploads_url"`
+	AccessToken      string  `json:"access_token"`
+	Drafts           bool    `json:"drafts"`
+	PreRelease       bool    `json:"pre_release"`
+	Release          bool    `json:"release"`
+	Version          Version `json:"version"`
 }
 
 type CheckRequest struct {
-	Source  Source  `json:"source"`
-	Version Version `json:"version"`
+	Source Source `json:"source"`
 }
 
 func NewCheckRequest() CheckRequest {


### PR DESCRIPTION
so, when setting a new pipeline, we are able to check and get old releases.

It seems most of the code was already there, but it was impossible to configure.

Fixes Issue #39 

with @jutkko and @henderjm