### PR TITLE
Source configuration uses owner instead of user

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Fetches and creates versioned GitHub resources.
 
 ## Source Configuration
 
-* `user`: *Required.* The GitHub username or organization name for the
-  repository that the releases are in.
+* `owner`: *Required.* The GitHub user or organization name for the repository
+  that the releases are in.
 
 * `repository`: *Required.* The repository name that contains the releases.
 
@@ -45,7 +45,7 @@ Fetches and creates versioned GitHub resources.
 - name: gh-release
   type: github-release
   source:
-    user: concourse
+    owner: concourse
     repository: concourse
     access_token: abcdef1234567890
 ```

--- a/github.go
+++ b/github.go
@@ -33,7 +33,7 @@ type GitHub interface {
 type GitHubClient struct {
 	client *github.Client
 
-	user       string
+	owner      string
 	repository string
 }
 
@@ -71,15 +71,20 @@ func NewGitHubClient(source Source) (*GitHubClient, error) {
 		}
 	}
 
+	owner := source.Owner
+	if source.User != "" {
+		owner = source.User
+	}
+
 	return &GitHubClient{
 		client:     client,
-		user:       source.User,
+		owner:      owner,
 		repository: source.Repository,
 	}, nil
 }
 
 func (g *GitHubClient) ListReleases() ([]*github.RepositoryRelease, error) {
-	releases, res, err := g.client.Repositories.ListReleases(g.user, g.repository, nil)
+	releases, res, err := g.client.Repositories.ListReleases(g.owner, g.repository, nil)
 	if err != nil {
 		return []*github.RepositoryRelease{}, err
 	}
@@ -93,7 +98,7 @@ func (g *GitHubClient) ListReleases() ([]*github.RepositoryRelease, error) {
 }
 
 func (g *GitHubClient) GetReleaseByTag(tag string) (*github.RepositoryRelease, error) {
-	release, res, err := g.client.Repositories.GetReleaseByTag(g.user, g.repository, tag)
+	release, res, err := g.client.Repositories.GetReleaseByTag(g.owner, g.repository, tag)
 	if err != nil {
 		return &github.RepositoryRelease{}, err
 	}
@@ -107,7 +112,7 @@ func (g *GitHubClient) GetReleaseByTag(tag string) (*github.RepositoryRelease, e
 }
 
 func (g *GitHubClient) GetRelease(id int) (*github.RepositoryRelease, error) {
-	release, res, err := g.client.Repositories.GetRelease(g.user, g.repository, id)
+	release, res, err := g.client.Repositories.GetRelease(g.owner, g.repository, id)
 	if err != nil {
 		return &github.RepositoryRelease{}, err
 	}
@@ -121,7 +126,7 @@ func (g *GitHubClient) GetRelease(id int) (*github.RepositoryRelease, error) {
 }
 
 func (g *GitHubClient) CreateRelease(release github.RepositoryRelease) (*github.RepositoryRelease, error) {
-	createdRelease, res, err := g.client.Repositories.CreateRelease(g.user, g.repository, &release)
+	createdRelease, res, err := g.client.Repositories.CreateRelease(g.owner, g.repository, &release)
 	if err != nil {
 		return &github.RepositoryRelease{}, err
 	}
@@ -139,7 +144,7 @@ func (g *GitHubClient) UpdateRelease(release github.RepositoryRelease) (*github.
 		return nil, errors.New("release did not have an ID: has it been saved yet?")
 	}
 
-	updatedRelease, res, err := g.client.Repositories.EditRelease(g.user, g.repository, *release.ID, &release)
+	updatedRelease, res, err := g.client.Repositories.EditRelease(g.owner, g.repository, *release.ID, &release)
 	if err != nil {
 		return &github.RepositoryRelease{}, err
 	}
@@ -153,7 +158,7 @@ func (g *GitHubClient) UpdateRelease(release github.RepositoryRelease) (*github.
 }
 
 func (g *GitHubClient) ListReleaseAssets(release github.RepositoryRelease) ([]*github.ReleaseAsset, error) {
-	assets, res, err := g.client.Repositories.ListReleaseAssets(g.user, g.repository, *release.ID, nil)
+	assets, res, err := g.client.Repositories.ListReleaseAssets(g.owner, g.repository, *release.ID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +173,7 @@ func (g *GitHubClient) ListReleaseAssets(release github.RepositoryRelease) ([]*g
 
 func (g *GitHubClient) UploadReleaseAsset(release github.RepositoryRelease, name string, file *os.File) error {
 	_, res, err := g.client.Repositories.UploadReleaseAsset(
-		g.user,
+		g.owner,
 		g.repository,
 		*release.ID,
 		&github.UploadOptions{
@@ -184,7 +189,7 @@ func (g *GitHubClient) UploadReleaseAsset(release github.RepositoryRelease, name
 }
 
 func (g *GitHubClient) DeleteReleaseAsset(asset github.ReleaseAsset) error {
-	res, err := g.client.Repositories.DeleteReleaseAsset(g.user, g.repository, *asset.ID)
+	res, err := g.client.Repositories.DeleteReleaseAsset(g.owner, g.repository, *asset.ID)
 	if err != nil {
 		return err
 	}
@@ -193,7 +198,7 @@ func (g *GitHubClient) DeleteReleaseAsset(asset github.ReleaseAsset) error {
 }
 
 func (g *GitHubClient) DownloadReleaseAsset(asset github.ReleaseAsset) (io.ReadCloser, error) {
-	res, redir, err := g.client.Repositories.DownloadReleaseAsset(g.user, g.repository, *asset.ID)
+	res, redir, err := g.client.Repositories.DownloadReleaseAsset(g.owner, g.repository, *asset.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +217,7 @@ func (g *GitHubClient) DownloadReleaseAsset(asset github.ReleaseAsset) (io.ReadC
 
 func (g *GitHubClient) GetTarballLink(tag string) (*url.URL, error) {
 	opt := &github.RepositoryContentGetOptions{Ref: tag}
-	u, res, err := g.client.Repositories.GetArchiveLink(g.user, g.repository, github.Tarball, opt)
+	u, res, err := g.client.Repositories.GetArchiveLink(g.owner, g.repository, github.Tarball, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +227,7 @@ func (g *GitHubClient) GetTarballLink(tag string) (*url.URL, error) {
 
 func (g *GitHubClient) GetZipballLink(tag string) (*url.URL, error) {
 	opt := &github.RepositoryContentGetOptions{Ref: tag}
-	u, res, err := g.client.Repositories.GetArchiveLink(g.user, g.repository, github.Zipball, opt)
+	u, res, err := g.client.Repositories.GetArchiveLink(g.owner, g.repository, github.Zipball, opt)
 	if err != nil {
 		return nil, err
 	}

--- a/github_test.go
+++ b/github_test.go
@@ -55,7 +55,7 @@ var _ = Describe("GitHub Client", func() {
 	Context("with an OAuth Token", func() {
 		BeforeEach(func() {
 			source = Source{
-				User:        "concourse",
+				Owner:       "concourse",
 				Repository:  "concourse",
 				AccessToken: "abc123",
 			}
@@ -78,7 +78,7 @@ var _ = Describe("GitHub Client", func() {
 	Context("without an OAuth Token", func() {
 		BeforeEach(func() {
 			source = Source{
-				User:       "concourse",
+				Owner:      "concourse",
 				Repository: "concourse",
 			}
 
@@ -97,10 +97,31 @@ var _ = Describe("GitHub Client", func() {
 		})
 	})
 
+	Describe("when the source is configured with the deprecated user field", func() {
+		BeforeEach(func() {
+			source = Source{
+				User:       "some-owner",
+				Repository: "some-repo",
+			}
+
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/repos/some-owner/some-repo/releases"),
+					ghttp.RespondWith(200, "[]"),
+				),
+			)
+		})
+
+		It("uses the provided user as the owner", func() {
+			_, err := client.ListReleases()
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+	})
+
 	Describe("GetRelease", func() {
 		BeforeEach(func() {
 			source = Source{
-				User:       "concourse",
+				Owner:      "concourse",
 				Repository: "concourse",
 			}
 		})
@@ -136,7 +157,7 @@ var _ = Describe("GitHub Client", func() {
 	Describe("GetReleaseByTag", func() {
 		BeforeEach(func() {
 			source = Source{
-				User:       "concourse",
+				Owner:      "concourse",
 				Repository: "concourse",
 			}
 		})

--- a/resources.go
+++ b/resources.go
@@ -1,8 +1,11 @@
 package resource
 
 type Source struct {
-	User       string `json:"user"`
+	Owner      string `json:"owner"`
 	Repository string `json:"repository"`
+
+	// Deprecated; use Owner instead
+	User string `json:"user"`
 
 	GitHubAPIURL     string `json:"github_api_url"`
 	GitHubUploadsURL string `json:"github_uploads_url"`


### PR DESCRIPTION
"Owner" is the name GitHub uses in its API to reference the owner of a
repository. "User" is not correct when the owner is an organization.

This removes some confusion I've encountered over how to configure the
resource while maintaining backwards compatibility.