### PR TITLE
Enable Skip TLS feature for Github Releases

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -13,6 +13,7 @@ type Source struct {
 	Drafts           bool   `json:"drafts"`
 	PreRelease       bool   `json:"pre_release"`
 	Release          bool   `json:"release"`
+	SkipSSLValidation bool  `json:"skip_ssl_verification"`
 }
 
 type CheckRequest struct {


### PR DESCRIPTION
Useful with customer MITM proxies that re-encrypt TLS with a custom or self-signed CA cert.