### PR TITLE
Resolve tag to commit SHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Also creates the following files:
 * `tag` containing the git tag name of the release being fetched.
 * `version` containing the version determined by the git tag of the release being fetched.
 * `body` containing the body text of the release.
+* `target_commit` containing the commit SHA the tag is pointing to.
 
 #### Parameters
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Also creates the following files:
 * `tag` containing the git tag name of the release being fetched.
 * `version` containing the version determined by the git tag of the release being fetched.
 * `body` containing the body text of the release.
-* `target_commit` containing the commit SHA the tag is pointing to.
+* `commit_sha` containing the commit SHA the tag is pointing to.
 
 #### Parameters
 

--- a/fakes/fake_git_hub.go
+++ b/fakes/fake_git_hub.go
@@ -109,6 +109,15 @@ type FakeGitHub struct {
 		result1 *url.URL
 		result2 error
 	}
+	GetRefStub        func(tag string) (*github.Reference, error)
+	getRefMutex       sync.RWMutex
+	getRefArgsForCall []struct {
+		tag string
+	}
+	getRefReturns struct {
+		result1 *github.Reference
+		result2 error
+	}
 }
 
 func (fake *FakeGitHub) ListReleases() ([]*github.RepositoryRelease, error) {
@@ -462,6 +471,39 @@ func (fake *FakeGitHub) GetZipballLinkReturns(result1 *url.URL, result2 error) {
 	fake.GetZipballLinkStub = nil
 	fake.getZipballLinkReturns = struct {
 		result1 *url.URL
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeGitHub) GetRef(tag string) (*github.Reference, error) {
+	fake.getRefMutex.Lock()
+	fake.getRefArgsForCall = append(fake.getRefArgsForCall, struct {
+		tag string
+	}{tag})
+	fake.getRefMutex.Unlock()
+	if fake.GetRefStub != nil {
+		return fake.GetRefStub(tag)
+	} else {
+		return fake.getRefReturns.result1, fake.getRefReturns.result2
+	}
+}
+
+func (fake *FakeGitHub) GetRefCallCount() int {
+	fake.getRefMutex.RLock()
+	defer fake.getRefMutex.RUnlock()
+	return len(fake.getRefArgsForCall)
+}
+
+func (fake *FakeGitHub) GetRefArgsForCall(i int) string {
+	fake.getRefMutex.RLock()
+	defer fake.getRefMutex.RUnlock()
+	return fake.getRefArgsForCall[i].tag
+}
+
+func (fake *FakeGitHub) GetRefReturns(result1 *github.Reference, result2 error) {
+	fake.GetRefStub = nil
+	fake.getRefReturns = struct {
+		result1 *github.Reference
 		result2 error
 	}{result1, result2}
 }

--- a/github.go
+++ b/github.go
@@ -31,6 +31,7 @@ type GitHub interface {
 
 	GetTarballLink(tag string) (*url.URL, error)
 	GetZipballLink(tag string) (*url.URL, error)
+	GetRef(tag string) (*github.Reference, error)
 }
 
 type GitHubClient struct {
@@ -245,6 +246,15 @@ func (g *GitHubClient) GetZipballLink(tag string) (*url.URL, error) {
 	}
 	res.Body.Close()
 	return u, nil
+}
+
+func (g *GitHubClient) GetRef(tag string) (*github.Reference, error) {
+	ref, res, err := g.client.Git.GetRef(context.TODO(), g.owner, g.repository, "tags/"+tag)
+	if err != nil {
+		return nil, err
+	}
+	res.Body.Close()
+	return ref, nil
 }
 
 func oauthClient(ctx context.Context, source Source) (*http.Client, error) {

--- a/github_test.go
+++ b/github_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/onsi/gomega/ghttp"
+	"github.com/google/go-github/github"
 )
 
 var _ = Describe("GitHub Client", func() {
@@ -195,14 +196,20 @@ var _ = Describe("GitHub Client", func() {
 				server.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/repos/concourse/concourse/releases/tags/some-tag"),
-						ghttp.RespondWith(200, "{}"),
+						ghttp.RespondWith(200, `{ "id": 1 }`),
 					),
 				)
 			})
 
-			It("Returns without error", func() {
-				_, err := client.GetReleaseByTag("some-tag")
+			It("Returns a populated github.RepositoryRelease", func() {
+				expectedRelease := &github.RepositoryRelease{
+					ID:         github.Int(1),
+				}
+
+				release, err := client.GetReleaseByTag("some-tag")
+
 				Ω(err).ShouldNot(HaveOccurred())
+				Expect(release).To(Equal(expectedRelease))
 			})
 		})
 	})
@@ -248,14 +255,20 @@ var _ = Describe("GitHub Client", func() {
 				server.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/repos/concourse/concourse/git/refs/tags/some-tag"),
-						ghttp.RespondWith(200, "{}"),
+						ghttp.RespondWith(200, `{ "ref": "refs/tags/some-tag" }`),
 					),
 				)
 			})
 
-			It("Returns without error", func() {
-				_, err := client.GetRef("some-tag")
+			It("Returns a populated github.Reference", func() {
+				expectedReference := &github.Reference{
+					Ref: github.String("refs/tags/some-tag"),
+				}
+
+				reference, err := client.GetRef("some-tag")
+
 				Ω(err).ShouldNot(HaveOccurred())
+				Expect(reference).To(Equal(expectedReference))
 			})
 		})
 	})

--- a/github_test.go
+++ b/github_test.go
@@ -161,6 +161,7 @@ var _ = Describe("GitHub Client", func() {
 				Repository: "concourse",
 			}
 		})
+
 		Context("When GitHub's rate limit has been exceeded", func() {
 			BeforeEach(func() {
 				rateLimitResponse := `{
@@ -188,6 +189,22 @@ var _ = Describe("GitHub Client", func() {
 				Expect(err.Error()).To(ContainSubstring("API rate limit exceeded for 127.0.0.1. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)"))
 			})
 		})
+
+		Context("When GitHub responds successfully", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/repos/concourse/concourse/releases/tags/some-tag"),
+						ghttp.RespondWith(200, "{}"),
+					),
+				)
+			})
+
+			It("Returns without error", func() {
+				_, err := client.GetReleaseByTag("some-tag")
+				Ω(err).ShouldNot(HaveOccurred())
+			})
+		})
 	})
 
 	Describe("GetRef", func() {
@@ -197,6 +214,7 @@ var _ = Describe("GitHub Client", func() {
 				Repository: "concourse",
 			}
 		})
+
 		Context("When GitHub's rate limit has been exceeded", func() {
 			BeforeEach(func() {
 				rateLimitResponse := `{
@@ -222,6 +240,22 @@ var _ = Describe("GitHub Client", func() {
 				_, err := client.GetRef("some-tag")
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(ContainSubstring("API rate limit exceeded for 127.0.0.1. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)"))
+			})
+		})
+
+		Context("When GitHub responds successfully", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/repos/concourse/concourse/git/refs/tags/some-tag"),
+						ghttp.RespondWith(200, "{}"),
+					),
+				)
+			})
+
+			It("Returns without error", func() {
+				_, err := client.GetRef("some-tag")
+				Ω(err).ShouldNot(HaveOccurred())
 			})
 		})
 	})

--- a/github_test.go
+++ b/github_test.go
@@ -189,4 +189,40 @@ var _ = Describe("GitHub Client", func() {
 			})
 		})
 	})
+
+	Describe("GetRef", func() {
+		BeforeEach(func() {
+			source = Source{
+				Owner:      "concourse",
+				Repository: "concourse",
+			}
+		})
+		Context("When GitHub's rate limit has been exceeded", func() {
+			BeforeEach(func() {
+				rateLimitResponse := `{
+          "message": "API rate limit exceeded for 127.0.0.1. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
+          "documentation_url": "https://developer.github.com/v3/#rate-limiting"
+        }`
+
+				rateLimitHeaders := http.Header(map[string][]string{
+					"X-RateLimit-Limit":     {"60"},
+					"X-RateLimit-Remaining": {"0"},
+					"X-RateLimit-Reset":     {"1377013266"},
+				})
+
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/repos/concourse/concourse/git/refs/tags/some-tag"),
+						ghttp.RespondWith(403, rateLimitResponse, rateLimitHeaders),
+					),
+				)
+			})
+
+			It("Returns an appropriate error", func() {
+				_, err := client.GetRef("some-tag")
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(ContainSubstring("API rate limit exceeded for 127.0.0.1. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)"))
+			})
+		})
+	})
 })

--- a/in_command.go
+++ b/in_command.go
@@ -62,7 +62,7 @@ func (c *InCommand) Run(destDir string, request InRequest) (InResponse, error) {
 			return InResponse{}, err
 		}
 
-		commitPath := filepath.Join(destDir, "target_commit")
+		commitPath := filepath.Join(destDir, "commit_sha")
 		commitSHA = c.resolveTagToCommitSHA(*foundRelease.TagName)
 		err = ioutil.WriteFile(commitPath, []byte(commitSHA), 0644)
 		if err != nil {

--- a/in_command.go
+++ b/in_command.go
@@ -199,10 +199,13 @@ func (c *InCommand) downloadFile(url, destPath string) error {
 
 func (c *InCommand) resolveTagToCommitSHA(tag string) (string, error) {
 	reference, err := c.github.GetRef(tag)
+	if err != nil {
+		return "", err
+	}
 
-	if err != nil && *reference.Object.Type != "commit" {
+	if *reference.Object.Type != "commit" {
 		fmt.Fprintln(c.writer, "could not resolve tag '%s' to commit: returned type is not 'commit' - only lightweight tags are supported")
-		return "", nil
+		return "", err
 	}
 
 	return *reference.Object.SHA, err

--- a/in_command_test.go
+++ b/in_command_test.go
@@ -142,7 +142,7 @@ var _ = Describe("In Command", func() {
 						resource.MetadataPair{Name: "name", Value: "release-name", URL: "http://google.com"},
 						resource.MetadataPair{Name: "body", Value: "*markdown*", Markdown: true},
 						resource.MetadataPair{Name: "tag", Value: "v0.35.0"},
-						resource.MetadataPair{Name: "commit_sha", Value: "f28085a4a8f744da83411f5e09fd7b1709149eee"},
+						resource.MetadataPair{Name: "target_commit", Value: "f28085a4a8f744da83411f5e09fd7b1709149eee"},
 					))
 				})
 
@@ -171,7 +171,7 @@ var _ = Describe("In Command", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					Ω(string(contents)).Should(Equal("0.35.0"))
 
-					contents, err = ioutil.ReadFile(path.Join(destDir, "commit_sha"))
+					contents, err = ioutil.ReadFile(path.Join(destDir, "target_commit"))
 					Ω(err).ShouldNot(HaveOccurred())
 					Ω(string(contents)).Should(Equal("f28085a4a8f744da83411f5e09fd7b1709149eee"))
 
@@ -361,7 +361,7 @@ var _ = Describe("In Command", func() {
 						resource.MetadataPair{Name: "name", Value: "release-name", URL: "http://google.com"},
 						resource.MetadataPair{Name: "body", Value: "*markdown*", Markdown: true},
 						resource.MetadataPair{Name: "tag", Value: "v0.35.0"},
-						resource.MetadataPair{Name: "commit_sha", Value: "f28085a4a8f744da83411f5e09fd7b1709149eee"},
+						resource.MetadataPair{Name: "target_commit", Value: "f28085a4a8f744da83411f5e09fd7b1709149eee"},
 					))
 				})
 
@@ -455,7 +455,7 @@ var _ = Describe("In Command", func() {
 					resource.MetadataPair{Name: "name", Value: "release-name", URL: "http://google.com"},
 					resource.MetadataPair{Name: "body", Value: "*markdown*", Markdown: true},
 					resource.MetadataPair{Name: "tag", Value: "v0.35.0"},
-					resource.MetadataPair{Name: "commit_sha", Value: "f28085a4a8f744da83411f5e09fd7b1709149eee"},
+					resource.MetadataPair{Name: "target_commit", Value: "f28085a4a8f744da83411f5e09fd7b1709149eee"},
 					resource.MetadataPair{Name: "draft", Value: "true"},
 				))
 			})
@@ -500,7 +500,7 @@ var _ = Describe("In Command", func() {
 			It("does not create the tag and version files", func() {
 				Ω(path.Join(destDir, "tag")).ShouldNot(BeAnExistingFile())
 				Ω(path.Join(destDir, "version")).ShouldNot(BeAnExistingFile())
-				Ω(path.Join(destDir, "commit_sha")).ShouldNot(BeAnExistingFile())
+				Ω(path.Join(destDir, "target_commit")).ShouldNot(BeAnExistingFile())
 			})
 		})
 

--- a/in_command_test.go
+++ b/in_command_test.go
@@ -468,6 +468,10 @@ var _ = Describe("In Command", func() {
 				contents, err = ioutil.ReadFile(path.Join(destDir, "version"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(string(contents)).Should(Equal("0.35.0"))
+
+				contents, err = ioutil.ReadFile(path.Join(destDir, "commit_sha"))
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(string(contents)).Should(Equal("f28085a4a8f744da83411f5e09fd7b1709149eee"))
 			})
 		})
 
@@ -532,6 +536,7 @@ var _ = Describe("In Command", func() {
 			It("does not create the tag and version files", func() {
 				Ω(path.Join(destDir, "tag")).ShouldNot(BeAnExistingFile())
 				Ω(path.Join(destDir, "version")).ShouldNot(BeAnExistingFile())
+				Ω(path.Join(destDir, "commit_sha")).ShouldNot(BeAnExistingFile())
 			})
 		})
 	})

--- a/in_command_test.go
+++ b/in_command_test.go
@@ -142,7 +142,7 @@ var _ = Describe("In Command", func() {
 						resource.MetadataPair{Name: "name", Value: "release-name", URL: "http://google.com"},
 						resource.MetadataPair{Name: "body", Value: "*markdown*", Markdown: true},
 						resource.MetadataPair{Name: "tag", Value: "v0.35.0"},
-						resource.MetadataPair{Name: "target_commit", Value: "f28085a4a8f744da83411f5e09fd7b1709149eee"},
+						resource.MetadataPair{Name: "commit_sha", Value: "f28085a4a8f744da83411f5e09fd7b1709149eee"},
 					))
 				})
 
@@ -171,7 +171,7 @@ var _ = Describe("In Command", func() {
 					Ω(err).ShouldNot(HaveOccurred())
 					Ω(string(contents)).Should(Equal("0.35.0"))
 
-					contents, err = ioutil.ReadFile(path.Join(destDir, "target_commit"))
+					contents, err = ioutil.ReadFile(path.Join(destDir, "commit_sha"))
 					Ω(err).ShouldNot(HaveOccurred())
 					Ω(string(contents)).Should(Equal("f28085a4a8f744da83411f5e09fd7b1709149eee"))
 
@@ -361,7 +361,7 @@ var _ = Describe("In Command", func() {
 						resource.MetadataPair{Name: "name", Value: "release-name", URL: "http://google.com"},
 						resource.MetadataPair{Name: "body", Value: "*markdown*", Markdown: true},
 						resource.MetadataPair{Name: "tag", Value: "v0.35.0"},
-						resource.MetadataPair{Name: "target_commit", Value: "f28085a4a8f744da83411f5e09fd7b1709149eee"},
+						resource.MetadataPair{Name: "commit_sha", Value: "f28085a4a8f744da83411f5e09fd7b1709149eee"},
 					))
 				})
 
@@ -455,7 +455,7 @@ var _ = Describe("In Command", func() {
 					resource.MetadataPair{Name: "name", Value: "release-name", URL: "http://google.com"},
 					resource.MetadataPair{Name: "body", Value: "*markdown*", Markdown: true},
 					resource.MetadataPair{Name: "tag", Value: "v0.35.0"},
-					resource.MetadataPair{Name: "target_commit", Value: "f28085a4a8f744da83411f5e09fd7b1709149eee"},
+					resource.MetadataPair{Name: "commit_sha", Value: "f28085a4a8f744da83411f5e09fd7b1709149eee"},
 					resource.MetadataPair{Name: "draft", Value: "true"},
 				))
 			})
@@ -500,7 +500,7 @@ var _ = Describe("In Command", func() {
 			It("does not create the tag and version files", func() {
 				Ω(path.Join(destDir, "tag")).ShouldNot(BeAnExistingFile())
 				Ω(path.Join(destDir, "version")).ShouldNot(BeAnExistingFile())
-				Ω(path.Join(destDir, "target_commit")).ShouldNot(BeAnExistingFile())
+				Ω(path.Join(destDir, "commit_sha")).ShouldNot(BeAnExistingFile())
 			})
 		})
 

--- a/metadata.go
+++ b/metadata.go
@@ -42,7 +42,7 @@ func metadataFromRelease(release *github.RepositoryRelease, commitSHA string) []
 
 	if commitSHA != "" {
 		metadata = append(metadata, MetadataPair{
-			Name:  "target_commit",
+			Name:  "commit_sha",
 			Value: commitSHA,
 		})
 	}

--- a/metadata.go
+++ b/metadata.go
@@ -2,7 +2,7 @@ package resource
 
 import "github.com/google/go-github/github"
 
-func metadataFromRelease(release *github.RepositoryRelease) []MetadataPair {
+func metadataFromRelease(release *github.RepositoryRelease, commitSHA string) []MetadataPair {
 	metadata := []MetadataPair{}
 
 	if release.Name != nil {
@@ -37,6 +37,13 @@ func metadataFromRelease(release *github.RepositoryRelease) []MetadataPair {
 		metadata = append(metadata, MetadataPair{
 			Name:  "tag",
 			Value: *release.TagName,
+		})
+	}
+
+	if commitSHA != "" {
+		metadata = append(metadata, MetadataPair{
+			Name:  "target_commit",
+			Value: commitSHA,
 		})
 	}
 

--- a/out_command.go
+++ b/out_command.go
@@ -145,7 +145,7 @@ func (c *OutCommand) Run(sourceDir string, request OutRequest) (OutResponse, err
 
 	return OutResponse{
 		Version:  versionFromRelease(release),
-		Metadata: metadataFromRelease(release),
+		Metadata: metadataFromRelease(release, ""),
 	}, nil
 }
 


### PR DESCRIPTION
## What challenge are you facing

We rely on commit SHAs quite heavily to tag and label containers. Some of them are fairly time-consuming to build and test, so when they were built once, we try to re-use the already existing artifact. (This also avoids problems of varying versions when installing packages carelessly during image creation). 

At this point, we have a step that "manually" resolves the lightweight tag produced by the Github Release into a commit SHA. This involves repeating authentication in this step, which is not too nice to set up in a task.

We suspect that more people might be interested in the commit SHA in order to run various pieces of automation.

## A modest proposal

This could be best solved by the Github Release API returning a proper `target_commit` which we could just use  to return.  Unfortunately it only returns a `target_commitish` which can be a SHA, tag or a branch name. This is not usable at this point.

Since releases are a more or less "rare" occurrence, we can afford to make an extra call to Github to resolve the tag for this release into an actual commit SHA. It looks like GitHub Releases only use lightweight tags, so this is fairly straightforward to do, as we have all authentication already in place.

Like `tag`, `version` and `body`, place a file called `commit_sha` into the workspace during the `in` step for the tasks to use later on.

