### PR TITLE
Skipping resolveTagToCommitSHA for drafts

### DIFF
--- a/in_command.go
+++ b/in_command.go
@@ -66,16 +66,18 @@ func (c *InCommand) Run(destDir string, request InRequest) (InResponse, error) {
 			return InResponse{}, err
 		}
 
-		commitPath := filepath.Join(destDir, "commit_sha")
-		commitSHA, err = c.resolveTagToCommitSHA(*foundRelease.TagName)
-		if err != nil {
-			return InResponse{}, err
-		}
-
-		if commitSHA != "" {
-			err = ioutil.WriteFile(commitPath, []byte(commitSHA), 0644)
+		if !request.Source.Drafts {
+			commitPath := filepath.Join(destDir, "commit_sha")
+			commitSHA, err = c.resolveTagToCommitSHA(*foundRelease.TagName)
 			if err != nil {
 				return InResponse{}, err
+			}
+
+			if commitSHA != "" {
+				err = ioutil.WriteFile(commitPath, []byte(commitSHA), 0644)
+				if err != nil {
+					return InResponse{}, err
+				}
 			}
 		}
 

--- a/in_command_test.go
+++ b/in_command_test.go
@@ -464,9 +464,9 @@ var _ = Describe("In Command", func() {
 		Context("which has a tag", func() {
 			BeforeEach(func() {
 				githubClient.GetReleaseReturns(buildRelease(1, "v0.35.0", true), nil)
-				githubClient.GetRefReturns(buildTagRef("v0.35.0", "f28085a4a8f744da83411f5e09fd7b1709149eee"), nil)
 
 				inRequest.Version = &resource.Version{ID: "1"}
+				inRequest.Source.Drafts = true
 				inResponse, inErr = command.Run(destDir, inRequest)
 			})
 
@@ -484,7 +484,6 @@ var _ = Describe("In Command", func() {
 					resource.MetadataPair{Name: "name", Value: "release-name", URL: "http://google.com"},
 					resource.MetadataPair{Name: "body", Value: "*markdown*", Markdown: true},
 					resource.MetadataPair{Name: "tag", Value: "v0.35.0"},
-					resource.MetadataPair{Name: "commit_sha", Value: "f28085a4a8f744da83411f5e09fd7b1709149eee"},
 					resource.MetadataPair{Name: "draft", Value: "true"},
 				))
 			})
@@ -497,10 +496,6 @@ var _ = Describe("In Command", func() {
 				contents, err = ioutil.ReadFile(path.Join(destDir, "version"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(string(contents)).Should(Equal("0.35.0"))
-
-				contents, err = ioutil.ReadFile(path.Join(destDir, "commit_sha"))
-				Ω(err).ShouldNot(HaveOccurred())
-				Ω(string(contents)).Should(Equal("f28085a4a8f744da83411f5e09fd7b1709149eee"))
 			})
 		})
 
@@ -509,6 +504,7 @@ var _ = Describe("In Command", func() {
 				githubClient.GetReleaseReturns(buildRelease(1, "", true), nil)
 
 				inRequest.Version = &resource.Version{ID: "1"}
+				inRequest.Source.Drafts = true
 				inResponse, inErr = command.Run(destDir, inRequest)
 			})
 
@@ -542,6 +538,7 @@ var _ = Describe("In Command", func() {
 				githubClient.GetReleaseReturns(buildNilTagRelease(1), nil)
 
 				inRequest.Version = &resource.Version{ID: "1"}
+				inRequest.Source.Drafts = true
 				inResponse, inErr = command.Run(destDir, inRequest)
 			})
 


### PR DESCRIPTION
Here is a quick fix for #70. The thing is that github does not create git tags for draft releases, that's basically why `resolveTagToCommitSHA()` is failing in case of drafts. I was wondering why `in_command` tests were not failing, but that's because there is a line in [in_command_test.go#L467](https://github.com/concourse/github-release-resource/blob/351c6d03fd046e82a5c23b2eb557eaa05820f8b0/in_command_test.go#L438) which kind of masking the failing call, assuming that `github.GetRef()` will return valid git reference, but in reality that call fails for drafts. I'm not sure of how to reflect real github api behavior in tests, like we can either remove the whole checking of `commit_sha` from context "when there is a draft release" "which has a tag", or... I dunno. I think removing that check will be fine, because of both: github doesn't create git tag for drafts, and this PR skips `resolveTagToCommitSHA()` for drafts.