### PR TITLE
Optionally sort releases by time rather than by version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Fetches and creates versioned GitHub resources.
   group is used as the release version; otherwise, the entire matching substring
   is used as the version.
 
+* `order_by`: *Optional. One of [`version`, `time`]. Default `version`.*
+   Selects whether to order releases by version (as extracted by `tag_filter`)
+   or by time. See `check` behavior described below for details.
+
 ### Example
 
 ``` yaml
@@ -94,14 +98,29 @@ To set a custom tag filter:
 
 ### `check`: Check for released versions.
 
-Releases are listed and sorted by their tag, using
-[semver](http://semver.org) semantics if possible. If `version` is specified, `check` returns releases from the specified version on. Otherwise, `check` returns the latest release.
+Lists releases, sorted either by their version or time, depending on the `order_by` source option.
+
+When sorting by version, the version is extracted from the git tag using the `tag_filter` source option.
+Versions are compared using [semver](http://semver.org) semantics if possible.
+
+When sorting by time and a release is published, it uses the publication time, otherwise it uses the creation time.
+
+The returned list contains an object of the following format for each release (with timestamp in the RFC3339 format):
+
+```
+{
+    "id": "12345",
+    "tag": "v1.2.3",
+    "timestamp": "2006-01-02T15:04:05.999999999Z"
+}
+```
+
+When `check` is given such an object as the `version` parameter, it returns releases from the specified version or time on.
+Otherwise it returns the release with the latest version or time.
 
 ### `in`: Fetch assets from a release.
 
-Fetches artifacts from the given release version. If the version is not
-specified, the latest version is chosen using [semver](http://semver.org)
-semantics.
+Fetches artifacts from the requested release.
 
 Also creates the following files:
 

--- a/check_command.go
+++ b/check_command.go
@@ -2,10 +2,7 @@ package resource
 
 import (
 	"sort"
-	"strconv"
-
 	"github.com/google/go-github/github"
-
 	"github.com/cppforlife/go-semi-semantic/version"
 )
 
@@ -19,6 +16,30 @@ func NewCheckCommand(github GitHub) *CheckCommand {
 	}
 }
 
+func SortByVersion(releases []*github.RepositoryRelease, versionParser *versionParser) {
+	sort.Slice(releases, func(i, j int) bool {
+		first, err := version.NewVersionFromString(versionParser.parse(*releases[i].TagName))
+		if err != nil {
+			return true
+		}
+
+		second, err := version.NewVersionFromString(versionParser.parse(*releases[j].TagName))
+		if err != nil {
+			return false
+		}
+
+		return first.IsLt(second)
+	})
+}
+
+func SortByTimestamp(releases []*github.RepositoryRelease) {
+	sort.Slice(releases, func(i, j int) bool {
+		a := releases[i]
+		b := releases[j]
+		return getTimestamp(a).Before(getTimestamp(b))
+	})
+}
+
 func (c *CheckCommand) Run(request CheckRequest) ([]Version, error) {
 	releases, err := c.github.ListReleases()
 	if err != nil {
@@ -29,6 +50,11 @@ func (c *CheckCommand) Run(request CheckRequest) ([]Version, error) {
 		return []Version{}, nil
 	}
 
+	orderByTime := false
+	if request.Source.OrderBy == "time" {
+		orderByTime = true
+	}
+
 	var filteredReleases []*github.RepositoryRelease
 
 	versionParser, err := newVersionParser(request.Source.TagFilter)
@@ -37,6 +63,7 @@ func (c *CheckCommand) Run(request CheckRequest) ([]Version, error) {
 	}
 
 	for _, release := range releases {
+
 		if request.Source.Drafts != *release.Draft {
 			continue
 		}
@@ -48,33 +75,42 @@ func (c *CheckCommand) Run(request CheckRequest) ([]Version, error) {
 			continue
 		}
 
-		if release.TagName == nil {
-			continue
-		}
-		if _, err := version.NewVersionFromString(versionParser.parse(*release.TagName)); err != nil {
-			continue
+		if orderByTime {
+			// We won't do anything with the tags, so just make sure the filter matches the tag.
+			var tag string
+			if release.TagName != nil { tag = *release.TagName }
+			if !versionParser.re.MatchString(tag) { continue }
+			// Skip releases with zero time
+			if getTimestamp(release).IsZero() { continue }
+		} else {
+			// We will sort by versions parsed out of tags, so make sure we parse successfully.
+			if release.TagName == nil {
+				continue
+			}
+			if _, err := version.NewVersionFromString(versionParser.parse(*release.TagName)); err != nil {
+				continue
+			}
 		}
 
 		filteredReleases = append(filteredReleases, release)
 	}
 
-	sort.Slice(filteredReleases, func(i, j int) bool {
-		first, err := version.NewVersionFromString(versionParser.parse(*filteredReleases[i].TagName))
-		if err != nil {
-			return true
-		}
-
-		second, err := version.NewVersionFromString(versionParser.parse(*filteredReleases[j].TagName))
-		if err != nil {
-			return false
-		}
-
-		return first.IsLt(second)
-	})
+	// If there are no valid releases, output an empty list.
 
 	if len(filteredReleases) == 0 {
 		return []Version{}, nil
 	}
+
+	// Sort releases by time or by version
+
+	if orderByTime {
+		SortByTimestamp(filteredReleases)
+	} else {
+		SortByVersion(filteredReleases, &versionParser)
+	}
+
+	// If request has no version, output the latest release
+
 	latestRelease := filteredReleases[len(filteredReleases)-1]
 
 	if (request.Version == Version{}) {
@@ -83,36 +119,47 @@ func (c *CheckCommand) Run(request CheckRequest) ([]Version, error) {
 		}, nil
 	}
 
-	if *latestRelease.TagName == request.Version.Tag {
-		return []Version{}, nil
+	// Find first release equal or later than the current version
+
+	var firstIncludedReleaseIndex int = -1
+
+	if orderByTime {
+		// Only search if request has a timestamp
+		if !request.Version.Timestamp.IsZero() {
+			firstIncludedReleaseIndex = sort.Search(len(filteredReleases), func (i int) bool {
+				release := filteredReleases[i]
+				return !getTimestamp(release).Before(request.Version.Timestamp)
+			})
+		}
+	} else {
+		requestVersion, err := version.NewVersionFromString(versionParser.parse(request.Version.Tag))
+		if err == nil {
+			firstIncludedReleaseIndex = sort.Search(len(filteredReleases), func (i int) bool {
+				release := filteredReleases[i]
+				releaseVersion, err := version.NewVersionFromString(versionParser.parse(*release.TagName))
+				if err != nil { return false }
+				return !releaseVersion.IsLt(requestVersion)
+			})
+		}
 	}
 
-	upToLatest := false
-	reversedVersions := []Version{}
+	// Output all releases equal or later than the current version,
+	// or just the latest release if there are no such releases.
 
-	for _, release := range filteredReleases {
-		if !upToLatest {
-			if *release.Draft || *release.Prerelease {
-				id := *release.ID
-				upToLatest = request.Version.ID == strconv.Itoa(id)
-			} else {
-				version := *release.TagName
-				upToLatest = request.Version.Tag == version
-			}
+	outputVersions := []Version{}
+
+	if firstIncludedReleaseIndex >= 0 && firstIncludedReleaseIndex < len(filteredReleases) {
+		// Found first release >= current version, so output this and all the following release versions
+		for i := firstIncludedReleaseIndex; i < len(filteredReleases); i++ {
+			outputVersions = append(outputVersions, versionFromRelease(filteredReleases[i]))
 		}
-
-		if upToLatest {
-			reversedVersions = append(reversedVersions, versionFromRelease(release))
-		}
-	}
-
-	if !upToLatest {
-		// current version was removed; start over from latest
-		reversedVersions = append(
-			reversedVersions,
+	} else {
+		// No release >= current version, so output the latest release version
+		outputVersions = append(
+			outputVersions,
 			versionFromRelease(filteredReleases[len(filteredReleases)-1]),
 		)
 	}
 
-	return reversedVersions, nil
+	return outputVersions, nil
 }

--- a/check_command.go
+++ b/check_command.go
@@ -1,9 +1,9 @@
 package resource
 
 import (
-	"sort"
-	"github.com/google/go-github/github"
 	"github.com/cppforlife/go-semi-semantic/version"
+	"github.com/google/go-github/github"
+	"sort"
 )
 
 type CheckCommand struct {
@@ -78,10 +78,16 @@ func (c *CheckCommand) Run(request CheckRequest) ([]Version, error) {
 		if orderByTime {
 			// We won't do anything with the tags, so just make sure the filter matches the tag.
 			var tag string
-			if release.TagName != nil { tag = *release.TagName }
-			if !versionParser.re.MatchString(tag) { continue }
+			if release.TagName != nil {
+				tag = *release.TagName
+			}
+			if !versionParser.re.MatchString(tag) {
+				continue
+			}
 			// Skip releases with zero time
-			if getTimestamp(release).IsZero() { continue }
+			if getTimestamp(release).IsZero() {
+				continue
+			}
 		} else {
 			// We will sort by versions parsed out of tags, so make sure we parse successfully.
 			if release.TagName == nil {
@@ -126,7 +132,7 @@ func (c *CheckCommand) Run(request CheckRequest) ([]Version, error) {
 	if orderByTime {
 		// Only search if request has a timestamp
 		if !request.Version.Timestamp.IsZero() {
-			firstIncludedReleaseIndex = sort.Search(len(filteredReleases), func (i int) bool {
+			firstIncludedReleaseIndex = sort.Search(len(filteredReleases), func(i int) bool {
 				release := filteredReleases[i]
 				return !getTimestamp(release).Before(request.Version.Timestamp)
 			})
@@ -134,10 +140,12 @@ func (c *CheckCommand) Run(request CheckRequest) ([]Version, error) {
 	} else {
 		requestVersion, err := version.NewVersionFromString(versionParser.parse(request.Version.Tag))
 		if err == nil {
-			firstIncludedReleaseIndex = sort.Search(len(filteredReleases), func (i int) bool {
+			firstIncludedReleaseIndex = sort.Search(len(filteredReleases), func(i int) bool {
 				release := filteredReleases[i]
 				releaseVersion, err := version.NewVersionFromString(versionParser.parse(*release.TagName))
-				if err != nil { return false }
+				if err != nil {
+					return false
+				}
 				return !releaseVersion.IsLt(requestVersion)
 			})
 		}

--- a/check_command.go
+++ b/check_command.go
@@ -84,7 +84,8 @@ func (c *CheckCommand) Run(request CheckRequest) ([]Version, error) {
 			if !versionParser.re.MatchString(tag) {
 				continue
 			}
-			// Skip releases with zero time
+			// We don't expect any releases with a missing (zero) timestamp,
+			// but we skip those just in case, since the data type includes them
 			if getTimestamp(release).IsZero() {
 				continue
 			}

--- a/check_command_test.go
+++ b/check_command_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Check Command", func() {
 			Context("and releases are ordered by time", func() {
 				It("returns no versions", func() {
 					versions, err := command.Run(resource.CheckRequest{
-						Source: resource.Source{ OrderBy: "time" },
+						Source: resource.Source{OrderBy: "time"},
 					})
 					Ω(err).ShouldNot(HaveOccurred())
 					Ω(versions).Should(BeEmpty())
@@ -94,7 +94,7 @@ var _ = Describe("Check Command", func() {
 					command := resource.NewCheckCommand(githubClient)
 
 					response, err := command.Run(resource.CheckRequest{
-						Source: resource.Source{ OrderBy: "time" },
+						Source: resource.Source{OrderBy: "time"},
 					})
 					Ω(err).ShouldNot(HaveOccurred())
 
@@ -520,7 +520,7 @@ var _ = Describe("Check Command", func() {
 
 						response, err := command.Run(resource.CheckRequest{
 							Version: newVersionWithTimestamp(3, "v0.1.3", 3),
-							Source:  resource.Source{ OrderBy: "time" },
+							Source:  resource.Source{OrderBy: "time"},
 						})
 						Ω(err).ShouldNot(HaveOccurred())
 
@@ -544,7 +544,7 @@ var _ = Describe("Check Command", func() {
 
 						response, err := command.Run(resource.CheckRequest{
 							Version: newVersionWithTimestamp(3, "v0.1.3", 3),
-							Source:  resource.Source{ OrderBy: "time" },
+							Source:  resource.Source{OrderBy: "time"},
 						})
 						Ω(err).ShouldNot(HaveOccurred())
 
@@ -568,7 +568,7 @@ var _ = Describe("Check Command", func() {
 
 						response, err := command.Run(resource.CheckRequest{
 							Version: newVersionWithTimestamp(2, "v0.2.1", 4),
-							Source:  resource.Source{ OrderBy: "time" },
+							Source:  resource.Source{OrderBy: "time"},
 						})
 						Ω(err).ShouldNot(HaveOccurred())
 
@@ -582,7 +582,7 @@ var _ = Describe("Check Command", func() {
 
 						response, err := command.Run(resource.CheckRequest{
 							Version: newVersionWithTimestamp(9, "v1.0.0", 3),
-							Source:  resource.Source{ OrderBy: "time" },
+							Source:  resource.Source{OrderBy: "time"},
 						})
 						Ω(err).ShouldNot(HaveOccurred())
 
@@ -595,8 +595,8 @@ var _ = Describe("Check Command", func() {
 						command := resource.NewCheckCommand(githubClient)
 
 						response, err := command.Run(resource.CheckRequest{
-							Version: resource.Version{ ID: "2", Tag: "v0.2.1" },
-							Source:  resource.Source{ OrderBy: "time" },
+							Version: resource.Version{ID: "2", Tag: "v0.2.1"},
+							Source:  resource.Source{OrderBy: "time"},
 						})
 						Ω(err).ShouldNot(HaveOccurred())
 
@@ -620,7 +620,7 @@ var _ = Describe("Check Command", func() {
 
 						response, err := command.Run(resource.CheckRequest{
 							Version: newVersionWithTimestamp(2, "v0.2.1", 3),
-							Source:  resource.Source{ OrderBy: "time" },
+							Source:  resource.Source{OrderBy: "time"},
 						})
 						Ω(err).ShouldNot(HaveOccurred())
 						Ω(response).Should(Equal([]resource.Version{}))

--- a/in_command.go
+++ b/in_command.go
@@ -36,7 +36,6 @@ func (c *InCommand) Run(destDir string, request InRequest) (InResponse, error) {
 
 	id, _ := strconv.Atoi(request.Version.ID)
 	foundRelease, err = c.github.GetRelease(id)
-
 	if err != nil {
 		return InResponse{}, err
 	}

--- a/in_command.go
+++ b/in_command.go
@@ -34,12 +34,9 @@ func (c *InCommand) Run(destDir string, request InRequest) (InResponse, error) {
 	var foundRelease *github.RepositoryRelease
 	var commitSHA string
 
-	if request.Version.Tag != "" {
-		foundRelease, err = c.github.GetReleaseByTag(request.Version.Tag)
-	} else {
-		id, _ := strconv.Atoi(request.Version.ID)
-		foundRelease, err = c.github.GetRelease(id)
-	}
+	id, _ := strconv.Atoi(request.Version.ID)
+	foundRelease, err = c.github.GetRelease(id)
+
 	if err != nil {
 		return InResponse{}, err
 	}
@@ -129,8 +126,8 @@ func (c *InCommand) Run(destDir string, request InRequest) (InResponse, error) {
 		}
 	}
 
-	if request.Params.IncludeSourceTarball {
-		u, err := c.github.GetTarballLink(request.Version.Tag)
+	if request.Params.IncludeSourceTarball && foundRelease.TagName != nil {
+		u, err := c.github.GetTarballLink(*foundRelease.TagName)
 		if err != nil {
 			return InResponse{}, err
 		}
@@ -140,8 +137,8 @@ func (c *InCommand) Run(destDir string, request InRequest) (InResponse, error) {
 		}
 	}
 
-	if request.Params.IncludeSourceZip {
-		u, err := c.github.GetZipballLink(request.Version.Tag)
+	if request.Params.IncludeSourceZip && foundRelease.TagName != nil {
+		u, err := c.github.GetZipballLink(*foundRelease.TagName)
 		if err != nil {
 			return InResponse{}, err
 		}

--- a/in_command_test.go
+++ b/in_command_test.go
@@ -101,7 +101,7 @@ var _ = Describe("In Command", func() {
 	Context("when there is a tagged release", func() {
 		Context("when a present version is specified", func() {
 			BeforeEach(func() {
-				githubClient.GetReleaseByTagReturns(buildRelease(1, "v0.35.0", false), nil)
+				githubClient.GetReleaseReturns(buildRelease(1, "v0.35.0", false), nil)
 				githubClient.GetRefReturns(buildTagRef("v0.35.0", "f28085a4a8f744da83411f5e09fd7b1709149eee"), nil)
 
 				githubClient.ListReleaseAssetsReturns([]*github.ReleaseAsset{
@@ -111,6 +111,7 @@ var _ = Describe("In Command", func() {
 				}, nil)
 
 				inRequest.Version = &resource.Version{
+					ID: "1",
 					Tag: "v0.35.0",
 				}
 			})
@@ -131,7 +132,7 @@ var _ = Describe("In Command", func() {
 				It("returns the fetched version", func() {
 					inResponse, inErr = command.Run(destDir, inRequest)
 
-					Ω(inResponse.Version).Should(Equal(resource.Version{Tag: "v0.35.0"}))
+					Ω(inResponse.Version).Should(Equal(resource.Version{ID: "1", Tag: "v0.35.0"}))
 				})
 
 				It("has some sweet metadata", func() {
@@ -146,10 +147,10 @@ var _ = Describe("In Command", func() {
 					))
 				})
 
-				It("calls #GetReleastByTag with the correct arguments", func() {
+				It("calls #GetReleast with the correct arguments", func() {
 					command.Run(destDir, inRequest)
 
-					Ω(githubClient.GetReleaseByTagArgsForCall(0)).Should(Equal("v0.35.0"))
+					Ω(githubClient.GetReleaseArgsForCall(0)).Should(Equal(1))
 				})
 
 				It("downloads only the files that match the globs", func() {
@@ -185,7 +186,7 @@ var _ = Describe("In Command", func() {
 						inRequest.Source = resource.Source{
 							TagFilter: "package-(.*)",
 						}
-						githubClient.GetReleaseByTagReturns(buildRelease(1, "package-0.35.0", false), nil)
+						githubClient.GetReleaseReturns(buildRelease(1, "package-0.35.0", false), nil)
 						githubClient.GetRefReturns(buildTagRef("package-0.35.0", "f28085a4a8f744da83411f5e09fd7b1709149eee"), nil)
 						inResponse, inErr = command.Run(destDir, inRequest)
 					})
@@ -381,7 +382,7 @@ var _ = Describe("In Command", func() {
 				})
 
 				It("returns the fetched version", func() {
-					Ω(inResponse.Version).Should(Equal(resource.Version{Tag: "v0.35.0"}))
+					Ω(inResponse.Version).Should(Equal(resource.Version{ID: "1", Tag: "v0.35.0"}))
 				})
 
 				It("has some sweet metadata", func() {
@@ -429,7 +430,7 @@ var _ = Describe("In Command", func() {
 
 	Context("when no tagged release is present", func() {
 		BeforeEach(func() {
-			githubClient.GetReleaseByTagReturns(nil, nil)
+			githubClient.GetReleaseReturns(nil, nil)
 
 			inRequest.Version = &resource.Version{
 				Tag: "v0.40.0",
@@ -447,7 +448,7 @@ var _ = Describe("In Command", func() {
 		disaster := errors.New("nope")
 
 		BeforeEach(func() {
-			githubClient.GetReleaseByTagReturns(nil, disaster)
+			githubClient.GetReleaseReturns(nil, disaster)
 
 			inRequest.Version = &resource.Version{
 				Tag: "some-tag",
@@ -474,7 +475,7 @@ var _ = Describe("In Command", func() {
 			})
 
 			It("returns the fetched version", func() {
-				Ω(inResponse.Version).Should(Equal(resource.Version{ID: "1"}))
+				Ω(inResponse.Version).Should(Equal(resource.Version{ID: "1", Tag: "v0.35.0"}))
 			})
 
 			It("has some sweet metadata", func() {

--- a/in_command_test.go
+++ b/in_command_test.go
@@ -111,7 +111,7 @@ var _ = Describe("In Command", func() {
 				}, nil)
 
 				inRequest.Version = &resource.Version{
-					ID: "1",
+					ID:  "1",
 					Tag: "v0.35.0",
 				}
 			})

--- a/resource_suite_test.go
+++ b/resource_suite_test.go
@@ -1,12 +1,12 @@
 package resource_test
 
 import (
+	"strconv"
 	"testing"
 	"time"
-	"strconv"
 
-	"github.com/google/go-github/github"
 	"github.com/concourse/github-release-resource"
+	"github.com/google/go-github/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -60,35 +60,35 @@ func newRepositoryReleaseWithCreatedTime(id int, version string, day int) *githu
 		Draft:      github.Bool(false),
 		Prerelease: github.Bool(false),
 		ID:         github.Int(id),
-		CreatedAt:  &github.Timestamp{ exampleTimeStamp(day) },
+		CreatedAt:  &github.Timestamp{exampleTimeStamp(day)},
 	}
 }
 
 func newRepositoryReleaseWithPublishedTime(id int, version string, day int) *github.RepositoryRelease {
 	return &github.RepositoryRelease{
-		TagName:    github.String(version),
-		Draft:      github.Bool(false),
-		Prerelease: github.Bool(false),
-		ID:         github.Int(id),
-		PublishedAt:  &github.Timestamp{ exampleTimeStamp(day) },
+		TagName:     github.String(version),
+		Draft:       github.Bool(false),
+		Prerelease:  github.Bool(false),
+		ID:          github.Int(id),
+		PublishedAt: &github.Timestamp{exampleTimeStamp(day)},
 	}
 }
 
 func newRepositoryReleaseWithCreatedAndPublishedTime(id int, version string, createdDay int, publishedDay int) *github.RepositoryRelease {
 	return &github.RepositoryRelease{
-		TagName:    github.String(version),
-		Draft:      github.Bool(false),
-		Prerelease: github.Bool(false),
-		ID:         github.Int(id),
-		CreatedAt:  &github.Timestamp{ exampleTimeStamp(createdDay) },
-		PublishedAt:  &github.Timestamp{ exampleTimeStamp(publishedDay) },
+		TagName:     github.String(version),
+		Draft:       github.Bool(false),
+		Prerelease:  github.Bool(false),
+		ID:          github.Int(id),
+		CreatedAt:   &github.Timestamp{exampleTimeStamp(createdDay)},
+		PublishedAt: &github.Timestamp{exampleTimeStamp(publishedDay)},
 	}
 }
 
 func newVersionWithTimestamp(id int, tag string, day int) resource.Version {
 	return resource.Version{
-		ID: strconv.Itoa(id),
-		Tag: tag,
+		ID:        strconv.Itoa(id),
+		Tag:       tag,
 		Timestamp: exampleTimeStamp(day),
 	}
 }

--- a/resource_suite_test.go
+++ b/resource_suite_test.go
@@ -2,8 +2,11 @@ package resource_test
 
 import (
 	"testing"
+	"time"
+	"strconv"
 
 	"github.com/google/go-github/github"
+	"github.com/concourse/github-release-resource"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -44,5 +47,48 @@ func newDraftWithNilTagRepositoryRelease(id int) *github.RepositoryRelease {
 		Draft:      github.Bool(true),
 		Prerelease: github.Bool(false),
 		ID:         github.Int(id),
+	}
+}
+
+func exampleTimeStamp(day int) time.Time {
+	return time.Date(2018, time.January, day, 0, 0, 0, 0, time.UTC)
+}
+
+func newRepositoryReleaseWithCreatedTime(id int, version string, day int) *github.RepositoryRelease {
+	return &github.RepositoryRelease{
+		TagName:    github.String(version),
+		Draft:      github.Bool(false),
+		Prerelease: github.Bool(false),
+		ID:         github.Int(id),
+		CreatedAt:  &github.Timestamp{ exampleTimeStamp(day) },
+	}
+}
+
+func newRepositoryReleaseWithPublishedTime(id int, version string, day int) *github.RepositoryRelease {
+	return &github.RepositoryRelease{
+		TagName:    github.String(version),
+		Draft:      github.Bool(false),
+		Prerelease: github.Bool(false),
+		ID:         github.Int(id),
+		PublishedAt:  &github.Timestamp{ exampleTimeStamp(day) },
+	}
+}
+
+func newRepositoryReleaseWithCreatedAndPublishedTime(id int, version string, createdDay int, publishedDay int) *github.RepositoryRelease {
+	return &github.RepositoryRelease{
+		TagName:    github.String(version),
+		Draft:      github.Bool(false),
+		Prerelease: github.Bool(false),
+		ID:         github.Int(id),
+		CreatedAt:  &github.Timestamp{ exampleTimeStamp(createdDay) },
+		PublishedAt:  &github.Timestamp{ exampleTimeStamp(publishedDay) },
+	}
+}
+
+func newVersionWithTimestamp(id int, tag string, day int) resource.Version {
+	return resource.Version{
+		ID: strconv.Itoa(id),
+		Tag: tag,
+		Timestamp: exampleTimeStamp(day),
 	}
 }

--- a/resources.go
+++ b/resources.go
@@ -1,7 +1,7 @@
 package resource
 
 import (
-    "time"
+	"time"
 )
 
 type Source struct {
@@ -19,8 +19,8 @@ type Source struct {
 	Release          bool   `json:"release"`
 	Insecure         bool   `json:"insecure"`
 
-	TagFilter       string  `json:"tag_filter"`
-	OrderBy         string  `json:"order_by"`
+	TagFilter string `json:"tag_filter"`
+	OrderBy   string `json:"order_by"`
 }
 
 type CheckRequest struct {
@@ -84,8 +84,8 @@ type OutResponse struct {
 }
 
 type Version struct {
-	Tag string `json:"tag,omitempty"`
-	ID  string `json:"id"`
+	Tag       string    `json:"tag,omitempty"`
+	ID        string    `json:"id"`
 	Timestamp time.Time `json:"timestamp"`
 }
 

--- a/resources.go
+++ b/resources.go
@@ -1,5 +1,9 @@
 package resource
 
+import (
+    "time"
+)
+
 type Source struct {
 	Owner      string `json:"owner"`
 	Repository string `json:"repository"`
@@ -15,7 +19,8 @@ type Source struct {
 	Release          bool   `json:"release"`
 	Insecure         bool   `json:"insecure"`
 
-	TagFilter string `json:"tag_filter"`
+	TagFilter       string  `json:"tag_filter"`
+	OrderBy         string  `json:"order_by"`
 }
 
 type CheckRequest struct {
@@ -80,7 +85,8 @@ type OutResponse struct {
 
 type Version struct {
 	Tag string `json:"tag,omitempty"`
-	ID  string `json:"id,omitempty"`
+	ID  string `json:"id"`
+	Timestamp time.Time `json:"timestamp"`
 }
 
 type MetadataPair struct {

--- a/versions.go
+++ b/versions.go
@@ -1,10 +1,10 @@
 package resource
 
 import (
+	"github.com/google/go-github/github"
 	"regexp"
 	"strconv"
 	"time"
-	"github.com/google/go-github/github"
 )
 
 var defaultTagFilter = "^v?([^v].*)"
@@ -43,8 +43,8 @@ func getTimestamp(release *github.RepositoryRelease) time.Time {
 }
 
 func versionFromRelease(release *github.RepositoryRelease) Version {
-	v := Version {
-		ID: strconv.Itoa(*release.ID),
+	v := Version{
+		ID:        strconv.Itoa(*release.ID),
 		Timestamp: getTimestamp(release),
 	}
 	if release.TagName != nil {

--- a/versions.go
+++ b/versions.go
@@ -3,7 +3,7 @@ package resource
 import (
 	"regexp"
 	"strconv"
-
+	"time"
 	"github.com/google/go-github/github"
 )
 
@@ -32,10 +32,23 @@ func (vp *versionParser) parse(tag string) string {
 	return ""
 }
 
-func versionFromRelease(release *github.RepositoryRelease) Version {
-	if *release.Draft {
-		return Version{ID: strconv.Itoa(*release.ID)}
+func getTimestamp(release *github.RepositoryRelease) time.Time {
+	if release.PublishedAt != nil {
+		return release.PublishedAt.Time
+	} else if release.CreatedAt != nil {
+		return release.CreatedAt.Time
 	} else {
-		return Version{Tag: *release.TagName}
+		return time.Time{}
 	}
+}
+
+func versionFromRelease(release *github.RepositoryRelease) Version {
+	v := Version {
+		ID: strconv.Itoa(*release.ID),
+		Timestamp: getTimestamp(release),
+	}
+	if release.TagName != nil {
+		v.Tag = *release.TagName
+	}
+	return v
 }


### PR DESCRIPTION
The main purpose of this PR is to implement optional ordering of releases by time rather than by version. Thus, newly created releases are reported by the concourse resource even if their tags contain version numbers lower than some previously created releases.

The user is given a choice to order releases by version or by time using a new source option `order_by` with possible values `version` and `time`.

This PR also makes some changes to avoid skipping releases when the user chooses to trigger the pipeline on every version of the resource and the last reported version is deleted. Specifically, `check` reports all releases newer than the "current" version or time given as a parameter, even if the current version is not found anymore.

Moreover, this PR changes the behavior when the "current" version provided to `check` is the latest version. In this case, it returns the current version rather than no versions. This is according to the behavior specified by the Concourse documentation: https://concourse-ci.org/implementing-resources.html

Finally, the resource versions reported by `check` and expected by `in` always contain three fields: `id`, `tag` and `timestamp`. We assume that each release has an ID, but not necessarily a tag. Therefore, `in` can always work with a release using the ID even if it does not have a tag.
