### PR TITLE
Generate files "draft" and "prerelease" indicating release type

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Also creates the following files:
 * `version` containing the version determined by the git tag of the release being fetched.
 * `body` containing the body text of the release.
 * `commit_sha` containing the commit SHA the tag is pointing to.
+* `prerelease` containing `1` for a prerelease, `0` otherwise.
+* `draft` containing `1` for a draft, `0` otherwise.
 
 #### Parameters
 

--- a/in_command.go
+++ b/in_command.go
@@ -62,6 +62,28 @@ func (c *InCommand) Run(destDir string, request InRequest) (InResponse, error) {
 			return InResponse{}, err
 		}
 
+		draftFlag := "0"
+		if foundRelease.Draft != nil && *foundRelease.Draft {
+			draftFlag = "1"
+		}
+
+		prereleaseFlag := "0"
+		if foundRelease.Prerelease != nil && *foundRelease.Prerelease {
+			prereleaseFlag = "1"
+		}
+
+		draftFlagPath := filepath.Join(destDir, "draft")
+		err = ioutil.WriteFile(draftFlagPath, []byte(draftFlag), 0644)
+		if err != nil {
+			return InResponse{}, err
+		}
+
+		prereleaseFlagPath := filepath.Join(destDir, "prerelease")
+		err = ioutil.WriteFile(prereleaseFlagPath, []byte(prereleaseFlag), 0644)
+		if err != nil {
+			return InResponse{}, err
+		}
+
 		if foundRelease.Draft != nil && !*foundRelease.Draft {
 			commitPath := filepath.Join(destDir, "commit_sha")
 			commitSHA, err = c.resolveTagToCommitSHA(*foundRelease.TagName)


### PR DESCRIPTION
Two additional files are generated by the "in" command:
- draft: containing 1 for draft releases, 0 otherwise
- prerelease: containing 1 for prereleases, 0 otherwise

Signed-off-by: Jakob Leben <jakob.leben@gmail.com>