### PR TITLE
behaviour: fix downloading assets with redirects

### DIFF
--- a/github.go
+++ b/github.go
@@ -37,7 +37,8 @@ type GitHub interface {
 }
 
 type GitHubClient struct {
-	client *github.Client
+	client     *github.Client
+	httpClient *http.Client
 
 	owner      string
 	repository string
@@ -93,6 +94,7 @@ func NewGitHubClient(source Source) (*GitHubClient, error) {
 
 	return &GitHubClient{
 		client:     client,
+		httpClient: httpClient,
 		owner:      owner,
 		repository: source.Repository,
 	}, nil
@@ -232,7 +234,12 @@ func (g *GitHubClient) DownloadReleaseAsset(asset github.ReleaseAsset) (io.ReadC
 		return bodyReader, err
 	}
 
-	resp, err := http.Get(redirectURL)
+	req, err := g.client.NewRequest("GET", redirectURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := g.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/github.go
+++ b/github.go
@@ -238,6 +238,7 @@ func (g *GitHubClient) DownloadReleaseAsset(asset github.ReleaseAsset) (io.ReadC
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/octet-stream")
 
 	resp, err := g.httpClient.Do(req)
 	if err != nil {

--- a/github_test.go
+++ b/github_test.go
@@ -380,6 +380,7 @@ var _ = Describe("GitHub Client", func() {
 					ghttp.VerifyRequest("GET", path),
 					ghttp.RespondWith(statusCode, body, headers...),
 					ghttp.VerifyHeaderKV("Authorization", "Bearer abc123"),
+					ghttp.VerifyHeaderKV("Accept", "application/octet-stream"),
 				),
 			)
 		}

--- a/github_test.go
+++ b/github_test.go
@@ -368,6 +368,7 @@ var _ = Describe("GitHub Client", func() {
 		BeforeEach(func() {
 			source.Owner = owner
 			source.Repository = repo
+			source.AccessToken = "abc123"
 			assetID = 42
 			asset = github.ReleaseAsset{ID: &assetID}
 			assetPath = fmt.Sprintf("/repos/%s/%s/releases/assets/%d", owner, repo, assetID)
@@ -378,6 +379,7 @@ var _ = Describe("GitHub Client", func() {
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", path),
 					ghttp.RespondWith(statusCode, body, headers...),
+					ghttp.VerifyHeaderKV("Authorization", "Bearer abc123"),
 				),
 			)
 		}


### PR DESCRIPTION
This PR addresses two issues around downloading assets that provide redirect URLs:

1. If an access token was provided, it should be used to download from a redirect URL (previously, these requests were made unauthenticated, which has a much lower rate limit)
1. Fixes #92 - set the `Accept` header to `application/octet-stream` as documented [here](https://developer.github.com/v3/repos/releases/#get-a-single-release-asset)