### PR TITLE
Fix graphql client creation when only v3 url is given

### DIFF
--- a/github.go
+++ b/github.go
@@ -84,7 +84,13 @@ func NewGitHubClient(source Source) (*GitHubClient, error) {
 			return nil, err
 		}
 
-		clientV4 = githubv4.NewEnterpriseClient(source.GitHubAPIURL+"graphql", httpClient)
+		var v4URL string
+		if strings.Contains(source.GitHubAPIURL, "v3") {
+			v4URL = strings.Replace(source.GitHubAPIURL, "v3/", "graphql", 1)
+		} else {
+			v4URL = source.GitHubAPIURL + "graphql"
+		}
+		clientV4 = githubv4.NewEnterpriseClient(v4URL, httpClient)
 	}
 
 	if source.GitHubV4APIURL != "" {

--- a/github.go
+++ b/github.go
@@ -85,8 +85,8 @@ func NewGitHubClient(source Source) (*GitHubClient, error) {
 		}
 
 		var v4URL string
-		if strings.Contains(source.GitHubAPIURL, "v3") {
-			v4URL = strings.Replace(source.GitHubAPIURL, "v3/", "graphql", 1)
+		if strings.HasSuffix(source.GitHubAPIURL, "/v3/") {
+			v4URL = source.GitHubAPIURL[:len(source.GitHubAPIURL)-4] + "/graphql"
 		} else {
 			v4URL = source.GitHubAPIURL + "graphql"
 		}

--- a/github.go
+++ b/github.go
@@ -86,7 +86,7 @@ func NewGitHubClient(source Source) (*GitHubClient, error) {
 
 		var v4URL string
 		if strings.HasSuffix(source.GitHubAPIURL, "/v3/") {
-			v4URL = source.GitHubAPIURL[:len(source.GitHubAPIURL)-4] + "/graphql"
+			v4URL = strings.TrimSuffix(source.GitHubAPIURL, "/v3/") + "/graphql"
 		} else {
 			v4URL = source.GitHubAPIURL + "graphql"
 		}

--- a/github_test.go
+++ b/github_test.go
@@ -154,6 +154,52 @@ var _ = Describe("GitHub Client", func() {
 		})
 	})
 
+	Context("with good URLs", func() {
+		var err error
+		BeforeEach(func() {
+			source = Source{
+				Owner:      "concourse",
+				Repository: "concourse",
+			}
+		})
+		Context("given only the v3 API endpoint", func() {
+			It("should replace v3 with graphql", func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", "/api/graphql"),
+						ghttp.RespondWith(200, singlePageResp),
+					),
+				)
+
+				source.GitHubAPIURL = server.URL() + "/api/v3"
+				//setting the access token is how we ensure the v4 client is used
+				source.AccessToken = "abc123"
+				client, err = NewGitHubClient(source)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				_, err := client.ListReleases()
+				Ω(err).ShouldNot(HaveOccurred())
+			})
+			It("should always append graphql", func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", "/api/graphql"),
+						ghttp.RespondWith(200, singlePageResp),
+					),
+				)
+
+				source.GitHubAPIURL = server.URL() + "/api/"
+				//setting the access token is how we ensure the v4 client is used
+				source.AccessToken = "abc123"
+				client, err = NewGitHubClient(source)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				_, err := client.ListReleases()
+				Ω(err).ShouldNot(HaveOccurred())
+			})
+		})
+	})
+
 	Context("with an OAuth Token", func() {
 		BeforeEach(func() {
 			source = Source{


### PR DESCRIPTION
fixes concourse/concourse#6373

This commit fixes the case where a user only provides this resource with
the `github_api_url` and not the `github_v4_api_url`. In this case the
code was appending "graphql" to the end of the provided GitHubAPIURL.
Seems this only affects github enterprise users depending on how they
configured their v3 and v4 URL's. Apparently something like this was
happening for enterprise users when the only set the github_api_url:

GitHubAPIURL = api.mygit.com/api/v3
would become
GitHubV4APIURL = GitHubAPIURL + "graphql" = api.mygit.com/api/v3/graphql

when they really wanted: api.mygit.com/api/graphql

(I actually have no idea what the github enterprise URL's would look like. They must be different from the public github instance where the previous client creation logic would have worked)

Another important thing to know is that the Github Client for v3 expects
the API URL to end with a "/". The code already ensures this during
creation of a v3 client.

For graphql it is expected that the v4 API URL does not end in a "/"