### PR TITLE
Graphqa api changes

### DIFF
--- a/github_graphql.go
+++ b/github_graphql.go
@@ -50,7 +50,7 @@ func (g *GitHubClient) listReleasesV4() ([]*github.RepositoryRelease, error) {
 			publishedAt, _ := time.ParseInLocation(time.RFC3339, r.Node.PublishedAt.Time.Format(time.RFC3339), time.UTC)
 			createdAt, _ := time.ParseInLocation(time.RFC3339, r.Node.CreatedAt.Time.Format(time.RFC3339), time.UTC)
 			var releaseID int64
-			if r.Node.DatabaseId == "" {
+			if r.Node.DatabaseId == 0 {
 				decodedID, err := base64.StdEncoding.DecodeString(r.Node.ID)
 				if err != nil {
 					return nil, err
@@ -65,12 +65,7 @@ func (g *GitHubClient) listReleasesV4() ([]*github.RepositoryRelease, error) {
 					return nil, err
 				}
 			} else {
-				var id int64
-				id, err := strconv.ParseInt(r.Node.DatabaseId, 10, 64)
-				if err != nil {
-					return nil, err
-				}
-				releaseID = id
+				releaseID = int64(r.Node.DatabaseId)
 			}
 
 			allReleases = append(allReleases, &github.RepositoryRelease{

--- a/github_graphql.go
+++ b/github_graphql.go
@@ -2,9 +2,7 @@ package resource
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
-	"regexp"
 	"strconv"
 	"time"
 
@@ -50,16 +48,7 @@ func (g *GitHubClient) listReleasesV4() ([]*github.RepositoryRelease, error) {
 			publishedAt, _ := time.ParseInLocation(time.RFC3339, r.Node.PublishedAt.Time.Format(time.RFC3339), time.UTC)
 			createdAt, _ := time.ParseInLocation(time.RFC3339, r.Node.CreatedAt.Time.Format(time.RFC3339), time.UTC)
 			var releaseID int64
-			decodedID, err := base64.StdEncoding.DecodeString(r.Node.ID)
-			if err != nil {
-				return nil, err
-			}
-			re := regexp.MustCompile(`.*[^\d]`)
-			decodedID = re.ReplaceAll(decodedID, []byte(""))
-			if string(decodedID) == "" {
-				return nil, errors.New("bad release id from graph ql api")
-			}
-			releaseID, err = strconv.ParseInt(string(decodedID), 10, 64)
+			releaseID, err := strconv.ParseInt(r.Node.DatabaseId, 10, 64)
 			if err != nil {
 				return nil, err
 			}

--- a/github_test.go
+++ b/github_test.go
@@ -25,6 +25,7 @@ const (
            "node": {
              "createdAt": "2010-10-01T00:58:07Z",
              "id": "MDc6UmVsZWFzZTMyMDk1MTAz",
+			 "databaseId": "32095103",
              "name": "xyz",
              "publishedAt": "2010-10-02T15:39:53Z",
              "tagName": "xyz",
@@ -37,6 +38,7 @@ const (
            "node": {
              "createdAt": "2010-08-27T13:55:36Z",
              "id": "MDc6UmVsZWFzZTMwMjMwNjU5",
+			 "databaseId": "30230659",
              "name": "xyz",
              "publishedAt": "2010-08-27T17:18:06Z",
              "tagName": "xyz",
@@ -64,6 +66,7 @@ const (
             "node": {
               "createdAt": "2010-10-10T01:01:07Z",
               "id": "MDc6UmVsZWFzZTMzMjIyMjQz",
+			  "databaseId":"33222243",
               "name": "xyq",
               "publishedAt": "2010-10-10T15:39:53Z",
               "tagName": "xyq",
@@ -90,6 +93,7 @@ const (
             "node": {
               "createdAt": "2010-10-10T01:01:07Z",
               "id": "MDc6UmVsZWFzZTMzMjZyzzzz",
+              "databaseId":"3322224a",
               "name": "xyq",
               "publishedAt": "2010-10-10T15:39:53Z",
               "tagName": "xyq",

--- a/github_test.go
+++ b/github_test.go
@@ -25,7 +25,7 @@ const (
            "node": {
              "createdAt": "2010-10-01T00:58:07Z",
              "id": "MDc6UmVsZWFzZTMyMDk1MTAz",
-			 "databaseId": "32095103",
+			 "databaseId": 32095103,
              "name": "xyz",
              "publishedAt": "2010-10-02T15:39:53Z",
              "tagName": "xyz",
@@ -38,7 +38,7 @@ const (
            "node": {
              "createdAt": "2010-08-27T13:55:36Z",
              "id": "MDc6UmVsZWFzZTMwMjMwNjU5",
-			 "databaseId": "30230659",
+			 "databaseId": 30230659,
              "name": "xyz",
              "publishedAt": "2010-08-27T17:18:06Z",
              "tagName": "xyz",
@@ -66,7 +66,7 @@ const (
             "node": {
               "createdAt": "2010-10-10T01:01:07Z",
               "id": "MDc6UmVsZWFzZTMzMjIyMjQz",
-			  "databaseId":"33222243",
+			  "databaseId": 33222243,
               "name": "xyq",
               "publishedAt": "2010-10-10T15:39:53Z",
               "tagName": "xyq",

--- a/model.go
+++ b/model.go
@@ -8,6 +8,7 @@ type ReleaseObject struct {
 	CreatedAt    githubv4.DateTime `graphql:"createdAt"`
 	PublishedAt  githubv4.DateTime `graphql:"publishedAt"`
 	ID           string            `graphql:"id"`
+	DatabaseId   string            `graphql:"databaseId"`
 	IsDraft      bool              `graphql:"isDraft"`
 	IsPrerelease bool              `graphql:"isPrerelease"`
 	Name         string            `graphql:"name"`

--- a/model.go
+++ b/model.go
@@ -8,7 +8,7 @@ type ReleaseObject struct {
 	CreatedAt    githubv4.DateTime `graphql:"createdAt"`
 	PublishedAt  githubv4.DateTime `graphql:"publishedAt"`
 	ID           string            `graphql:"id"`
-	DatabaseId   string            `graphql:"databaseId"`
+	DatabaseId   githubv4.Int      `graphql:"databaseId"`
 	IsDraft      bool              `graphql:"isDraft"`
 	IsPrerelease bool              `graphql:"isPrerelease"`
 	Name         string            `graphql:"name"`


### PR DESCRIPTION
After  today github release the id  field is now changing the format, so resource  is returning `error running command: illegal base64 data at input byte 2`
https://docs.github.com/en/graphql/reference/objects#release