### PR TITLE
Create `timestamp` file on `in` operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Also creates the following files:
 * `tag` containing the git tag name of the release being fetched.
 * `version` containing the version determined by the git tag of the release being fetched.
 * `body` containing the body text of the release.
+* `timestamp` containing the publish or creation timestamp for the release in RFC 3339 format.
 * `commit_sha` containing the commit SHA the tag is pointing to.
 * `url` containing the HTMLURL for the release being fetched.
 

--- a/in_command.go
+++ b/in_command.go
@@ -3,13 +3,14 @@ package resource
 import (
 	"errors"
 	"fmt"
-	"github.com/google/go-github/v39/github"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/google/go-github/v39/github"
 )
 
 type InCommand struct {
@@ -91,6 +92,18 @@ func (c *InCommand) Run(destDir string, request InRequest) (InResponse, error) {
 			body := *foundRelease.Body
 			bodyPath := filepath.Join(destDir, "body")
 			err = ioutil.WriteFile(bodyPath, []byte(body), 0644)
+			if err != nil {
+				return InResponse{}, err
+			}
+		}
+
+		if foundRelease.PublishedAt != nil || foundRelease.CreatedAt != nil {
+			timestampPath := filepath.Join(destDir, "timestamp")
+			timestamp, err := getTimestamp(foundRelease).MarshalText()
+			if err != nil {
+				return InResponse{}, err
+			}
+			err = ioutil.WriteFile(timestampPath, timestamp, 0644)
 			if err != nil {
 				return InResponse{}, err
 			}

--- a/in_command_test.go
+++ b/in_command_test.go
@@ -58,13 +58,15 @@ var _ = Describe("In Command", func() {
 
 	buildRelease := func(id int64, tag string, draft bool) *github.RepositoryRelease {
 		return &github.RepositoryRelease{
-			ID:         github.Int64(id),
-			TagName:    github.String(tag),
-			HTMLURL:    github.String("http://google.com"),
-			Name:       github.String("release-name"),
-			Body:       github.String("*markdown*"),
-			Draft:      github.Bool(draft),
-			Prerelease: github.Bool(false),
+			ID:          github.Int64(id),
+			TagName:     github.String(tag),
+			HTMLURL:     github.String("http://google.com"),
+			Name:        github.String("release-name"),
+			Body:        github.String("*markdown*"),
+			CreatedAt:   &github.Timestamp{Time: exampleTimeStamp(1)},
+			PublishedAt: &github.Timestamp{Time: exampleTimeStamp(1)},
+			Draft:       github.Bool(draft),
+			Prerelease:  github.Bool(false),
 		}
 	}
 
@@ -74,6 +76,7 @@ var _ = Describe("In Command", func() {
 			HTMLURL:    github.String("http://google.com"),
 			Name:       github.String("release-name"),
 			Body:       github.String("*markdown*"),
+			CreatedAt:  &github.Timestamp{Time: exampleTimeStamp(1)},
 			Draft:      github.Bool(true),
 			Prerelease: github.Bool(false),
 		}
@@ -120,7 +123,7 @@ var _ = Describe("In Command", func() {
 				It("returns the fetched version", func() {
 					inResponse, inErr = command.Run(destDir, inRequest)
 
-					Ω(inResponse.Version).Should(Equal(resource.Version{ID: "1", Tag: "v0.35.0"}))
+					Ω(inResponse.Version).Should(Equal(newVersionWithTimestamp(1, "v0.35.0", 1)))
 				})
 
 				It("has some sweet metadata", func() {
@@ -167,6 +170,10 @@ var _ = Describe("In Command", func() {
 					contents, err = ioutil.ReadFile(path.Join(destDir, "body"))
 					Ω(err).ShouldNot(HaveOccurred())
 					Ω(string(contents)).Should(Equal("*markdown*"))
+
+					contents, err = ioutil.ReadFile(path.Join(destDir, "timestamp"))
+					Ω(err).ShouldNot(HaveOccurred())
+					Ω(string(contents)).Should(Equal("2018-01-01T00:00:00Z"))
 
 					contents, err = ioutil.ReadFile(path.Join(destDir, "url"))
 					Ω(err).ShouldNot(HaveOccurred())
@@ -378,7 +385,7 @@ var _ = Describe("In Command", func() {
 				})
 
 				It("returns the fetched version", func() {
-					Ω(inResponse.Version).Should(Equal(resource.Version{ID: "1", Tag: "v0.35.0"}))
+					Ω(inResponse.Version).Should(Equal(newVersionWithTimestamp(1, "v0.35.0", 1)))
 				})
 
 				It("has some sweet metadata", func() {
@@ -471,7 +478,7 @@ var _ = Describe("In Command", func() {
 			})
 
 			It("returns the fetched version", func() {
-				Ω(inResponse.Version).Should(Equal(resource.Version{ID: "1", Tag: "v0.35.0"}))
+				Ω(inResponse.Version).Should(Equal(newVersionWithTimestamp(1, "v0.35.0", 1)))
 			})
 
 			It("has some sweet metadata", func() {
@@ -512,7 +519,7 @@ var _ = Describe("In Command", func() {
 			})
 
 			It("returns the fetched version", func() {
-				Ω(inResponse.Version).Should(Equal(resource.Version{ID: "1"}))
+				Ω(inResponse.Version).Should(Equal(newVersionWithTimestamp(1, "", 1)))
 			})
 
 			It("has some sweet metadata", func() {
@@ -551,7 +558,7 @@ var _ = Describe("In Command", func() {
 			})
 
 			It("returns the fetched version", func() {
-				Ω(inResponse.Version).Should(Equal(resource.Version{ID: "1"}))
+				Ω(inResponse.Version).Should(Equal(newVersionWithTimestamp(1, "", 1)))
 			})
 
 			It("has some sweet metadata", func() {


### PR DESCRIPTION
The more accurate field should be `published_at`, but the versions logic also uses `created_at` for what I assume to be draft releases, so I just copied that logic as well.