### PR TITLE
skip not uploaded assets

### DIFF
--- a/in_command.go
+++ b/in_command.go
@@ -116,6 +116,11 @@ func (c *InCommand) Run(destDir string, request InRequest) (InResponse, error) {
 	}
 
 	for _, asset := range assets {
+		state := asset.State
+		if state == nil || *state != "uploaded" {
+			continue
+		}
+
 		path := filepath.Join(destDir, *asset.Name)
 
 		var matchFound bool

--- a/in_command_test.go
+++ b/in_command_test.go
@@ -83,9 +83,20 @@ var _ = Describe("In Command", func() {
 	}
 
 	buildAsset := func(id int64, name string) *github.ReleaseAsset {
+		state := "uploaded"
 		return &github.ReleaseAsset{
-			ID:   github.Int64(id),
-			Name: &name,
+			ID:    github.Int64(id),
+			Name:  &name,
+			State: &state,
+		}
+	}
+
+	buildFailedAsset := func(id int64, name string) *github.ReleaseAsset {
+		state := "starter"
+		return &github.ReleaseAsset{
+			ID:    github.Int64(id),
+			Name:  &name,
+			State: &state,
 		}
 	}
 
@@ -99,6 +110,7 @@ var _ = Describe("In Command", func() {
 					buildAsset(0, "example.txt"),
 					buildAsset(1, "example.rtf"),
 					buildAsset(2, "example.wtf"),
+					buildFailedAsset(3, "example.doc"),
 				}, nil)
 
 				inRequest.Version = &resource.Version{
@@ -402,6 +414,7 @@ var _ = Describe("In Command", func() {
 					Ω(githubClient.DownloadReleaseAssetArgsForCall(0)).Should(Equal(*buildAsset(0, "example.txt")))
 					Ω(githubClient.DownloadReleaseAssetArgsForCall(1)).Should(Equal(*buildAsset(1, "example.rtf")))
 					Ω(githubClient.DownloadReleaseAssetArgsForCall(2)).Should(Equal(*buildAsset(2, "example.wtf")))
+					Ω(githubClient.DownloadReleaseAssetCallCount()).Should(Equal(3))
 				})
 			})
 


### PR DESCRIPTION
Sometimes, an asset upload would fail, leaving the state of the asset in `starter`, instead of `uploaded`
In those cases, we want to skip the asset, otherwise download will fail with

```
error running command: redirect URL "https://objects.githubusercontent.com/github-production-release-asset/...
```