### PR TITLE
fix: escape unicode characters in `get` step

### DIFF
--- a/in_command.go
+++ b/in_command.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/google/go-github/v66/github"
 )
@@ -105,6 +106,13 @@ func (c *InCommand) Run(destDir string, request InRequest) (InResponse, error) {
 			if err != nil {
 				return InResponse{}, err
 			}
+
+			// Escape UTF-8 characters for Concourse metadata
+			body = strconv.QuoteToASCII(*foundRelease.Body)
+			body = strings.Replace(body, `\n`, "\n", -1)
+			body = strings.Replace(body, `\r`, "\r", -1)
+			body = strings.Replace(body, `\t`, "\t", -1)
+			foundRelease.Body = &body
 		}
 
 		if foundRelease.PublishedAt != nil || foundRelease.CreatedAt != nil {


### PR DESCRIPTION
- Only replaces on the concourse metadata, not the output file
- Without this, concourse GRPC will fail stating that the string contains unknown UTF-8 even if the body is valid UTF-8 according to go.

I'm happy to explore other options, however go's own `utf8.ValidString` considers the body from knative/operator as valid UTF-8 whereas Concourse does not. Since this only affects the Concourse metadata on the `get` step I think this is a reasonable compromise.

Fixes #128 