### PR TITLE
optionally put assets in separate dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Fetches and creates versioned GitHub resources.
    Selects whether to order releases by version (as extracted by `tag_filter`)
    or by time. See `check` behavior described below for details.
 
+* `asset_dir`:  *Optional. Default `false`.* When set to `true`, downloaded assets
+  will be created in a separate directory called `assets`. Otherwise, they will be
+  created in the same directory as the other files.
+
 ### Example
 
 ``` yaml
@@ -135,7 +139,8 @@ Otherwise it returns the release with the latest version or time.
 
 ### `in`: Fetch assets from a release.
 
-Fetches artifacts from the requested release.
+Fetches artifacts from the requested release.  If `asset_dir` source param is set to `true`,
+artifacts will be created in a subdirectory called `assets`.
 
 Also creates the following files:
 

--- a/in_command.go
+++ b/in_command.go
@@ -31,6 +31,16 @@ func (c *InCommand) Run(destDir string, request InRequest) (InResponse, error) {
 		return InResponse{}, err
 	}
 
+	// if AssetDir is true, create a separate directory for assets
+	assetDir := destDir
+	if request.Source.AssetDir {
+		assetDir = filepath.Join(destDir, "assets")
+		err = os.MkdirAll(assetDir, 0755)
+		if err != nil {
+			return InResponse{}, err
+		}
+	}
+
 	var foundRelease *github.RepositoryRelease
 	var commitSHA string
 
@@ -121,7 +131,7 @@ func (c *InCommand) Run(destDir string, request InRequest) (InResponse, error) {
 			continue
 		}
 
-		path := filepath.Join(destDir, *asset.Name)
+		path := filepath.Join(assetDir, *asset.Name)
 
 		var matchFound bool
 		if len(request.Params.Globs) == 0 {
@@ -158,7 +168,7 @@ func (c *InCommand) Run(destDir string, request InRequest) (InResponse, error) {
 			return InResponse{}, err
 		}
 		fmt.Fprintln(c.writer, "downloading source tarball to source.tar.gz")
-		if err := c.downloadFile(u.String(), filepath.Join(destDir, "source.tar.gz")); err != nil {
+		if err := c.downloadFile(u.String(), filepath.Join(assetDir, "source.tar.gz")); err != nil {
 			return InResponse{}, err
 		}
 	}
@@ -169,7 +179,7 @@ func (c *InCommand) Run(destDir string, request InRequest) (InResponse, error) {
 			return InResponse{}, err
 		}
 		fmt.Fprintln(c.writer, "downloading source zip to source.zip")
-		if err := c.downloadFile(u.String(), filepath.Join(destDir, "source.zip")); err != nil {
+		if err := c.downloadFile(u.String(), filepath.Join(assetDir, "source.zip")); err != nil {
 			return InResponse{}, err
 		}
 	}

--- a/in_command_test.go
+++ b/in_command_test.go
@@ -270,6 +270,16 @@ var _ = Describe("In Command", func() {
 								Expect(err).NotTo(HaveOccurred())
 								Expect(fContents).To(Equal("source-tar-file-contents"))
 							})
+
+							It("saves the source tarball in the assets directory, if desired", func() {
+								inRequest.Source.AssetDir = true
+								inResponse, inErr = command.Run(destDir, inRequest)
+
+								fileContents, err := ioutil.ReadFile(filepath.Join(destDir, "assets", "source.tar.gz"))
+								fContents := string(fileContents)
+								Expect(err).NotTo(HaveOccurred())
+								Expect(fContents).To(Equal("source-tar-file-contents"))
+							})
 						})
 
 						Context("when downloading the tarball fails", func() {
@@ -346,6 +356,16 @@ var _ = Describe("In Command", func() {
 								inResponse, inErr = command.Run(destDir, inRequest)
 
 								fileContents, err := ioutil.ReadFile(filepath.Join(destDir, "source.zip"))
+								fContents := string(fileContents)
+								Expect(err).NotTo(HaveOccurred())
+								Expect(fContents).To(Equal("source-zip-file-contents"))
+							})
+
+							It("saves the source tarball in the assets directory, if desired", func() {
+								inRequest.Source.AssetDir = true
+								inResponse, inErr = command.Run(destDir, inRequest)
+
+								fileContents, err := ioutil.ReadFile(filepath.Join(destDir, "assets", "source.tar.gz"))
 								fContents := string(fileContents)
 								Expect(err).NotTo(HaveOccurred())
 								Expect(fContents).To(Equal("source-zip-file-contents"))

--- a/in_command_test.go
+++ b/in_command_test.go
@@ -365,7 +365,7 @@ var _ = Describe("In Command", func() {
 								inRequest.Source.AssetDir = true
 								inResponse, inErr = command.Run(destDir, inRequest)
 
-								fileContents, err := ioutil.ReadFile(filepath.Join(destDir, "assets", "source.tar.gz"))
+								fileContents, err := ioutil.ReadFile(filepath.Join(destDir, "assets", "source.zip"))
 								fContents := string(fileContents)
 								Expect(err).NotTo(HaveOccurred())
 								Expect(fContents).To(Equal("source-zip-file-contents"))

--- a/resources.go
+++ b/resources.go
@@ -19,6 +19,7 @@ type Source struct {
 	PreRelease       bool   `json:"pre_release"`
 	Release          bool   `json:"release"`
 	Insecure         bool   `json:"insecure"`
+	AssetDir         bool   `json:"asset_dir"`
 
 	TagFilter        string `json:"tag_filter"`
 	OrderBy          string `json:"order_by"`


### PR DESCRIPTION
After fetching a release with several artifact files, I want to use a shell script to iterate over those files in a task. Ideally, the shell code would look something like this:

```sh
for i in *; do
  do_something_to_an_artifact "$i"
done
```

The problem is that these artifacts coexist in the same directory with metadata files `tag`, `version`, `body`, `timestamp`, `commit_sha`, and `url`.  The `*` glob will include those metadata files, but I only want it to include the artifacts downloaded from the GitHub release.  

So, I propose adding a new boolean source parameter called `asset_dir`.  When enabled, the resource will put the artifacts in a new subdirectory called `assets`.  

I tested my changes with `asset_dir` unset, and the resource downloaded the artifacts to the same directory as the metadata files, preserving the existing behavior.  When I tested my changes with `asset_dir` set to `true`, the artifacts ended up in a new subdirectory as expected.  

Thank you for reading my pull-request!
