### PR TITLE
Fix pagination to fetch all release assets 

### DIFF
--- a/github.go
+++ b/github.go
@@ -227,12 +227,6 @@ func (g *GitHubClient) ListReleaseAssets(release github.RepositoryRelease) ([]*g
 			break
 		}
 		opt.Page = res.NextPage
-
-		err = res.Body.Close()
-		if err != nil {
-			return nil, err
-		}
-		break
 	}
 
 	return allAssets, nil


### PR DESCRIPTION
Closes: #139

Fix pagination to fetch all release assets and add coverage tests.

Related:
#133
#134
### Notes to reviewer

Eliminates the premature `break` to correctly iterate over all pages of assets using `res.NextPage`, 
resolving the previous limitation where only the first 100 assets were retrieved.

I've tested it with custom resource based on [github-release-resource](https://github.com/concourse/github-release-resource) and following pipeline:
```yaml
resource_types:
- name: custom-resource
  type: registry-image
  source:
    repository: ichalukov/custom-resource
    tag: latest

resources:
- name: openjdk-release
  type: custom-resource
  source:
    owner: bell-sw
    repository: Liberica
    access_token: ((github_token))
    semver_constraint: "~23"

jobs:
  - name: check-openjdk-release
    plan:
      - get: openjdk-release
        params:
          globs:
            - "bellsoft-jre*-linux-amd64.tar.gz"
      - task: list-assets
        config:
          platform: linux
          image_resource:
            type: registry-image
            source:
              repository: busybox
          inputs:
            - name: openjdk-release
          run:
            path: sh
            args:
              - -c
              - |
                echo "Listing contents of openjdk-release directory:"
                ls -al openjdk-release || echo "(no files downloaded)"

```
