### PR TITLE
Fix 422 error when updating release without commitish parameter

### DIFF
--- a/out_command.go
+++ b/out_command.go
@@ -49,9 +49,7 @@ func (c *OutCommand) Run(sourceDir string, request OutRequest) (OutResponse, err
 	}
 
 	var targetCommitish string
-	commitishSpecified := false
 	if request.Params.CommitishPath != "" {
-		commitishSpecified = true
 		targetCommitish, err = c.fileContents(filepath.Join(sourceDir, request.Params.CommitishPath))
 		if err != nil {
 			return OutResponse{}, err
@@ -99,10 +97,8 @@ func (c *OutCommand) Run(sourceDir string, request OutRequest) (OutResponse, err
 		existingRelease.Draft = github.Bool(draft)
 		existingRelease.Prerelease = github.Bool(prerelease)
 
-		if commitishSpecified {
+		if targetCommitish != "" {
 			existingRelease.TargetCommitish = github.String(targetCommitish)
-		} else {
-			existingRelease.TargetCommitish = nil
 		}
 
 		if bodySpecified {

--- a/out_command.go
+++ b/out_command.go
@@ -48,8 +48,10 @@ func (c *OutCommand) Run(sourceDir string, request OutRequest) (OutResponse, err
 		}
 	}
 
-	targetCommitish := ""
+	var targetCommitish string
+	commitishSpecified := false
 	if request.Params.CommitishPath != "" {
+		commitishSpecified = true
 		targetCommitish, err = c.fileContents(filepath.Join(sourceDir, request.Params.CommitishPath))
 		if err != nil {
 			return OutResponse{}, err
@@ -94,9 +96,14 @@ func (c *OutCommand) Run(sourceDir string, request OutRequest) (OutResponse, err
 		}
 
 		existingRelease.Name = github.String(name)
-		existingRelease.TargetCommitish = github.String(targetCommitish)
 		existingRelease.Draft = github.Bool(draft)
 		existingRelease.Prerelease = github.Bool(prerelease)
+
+		if commitishSpecified {
+			existingRelease.TargetCommitish = github.String(targetCommitish)
+		} else {
+			existingRelease.TargetCommitish = nil
+		}
 
 		if bodySpecified {
 			existingRelease.Body = github.String(body)

--- a/out_command_test.go
+++ b/out_command_test.go
@@ -185,7 +185,7 @@ var _ = Describe("Out Command", func() {
 		})
 
 		Context("when a commitish is not supplied", func() {
-			It("does not update the target commitish", func() {
+			It("updates the existing release", func() {
 				_, err := command.Run(sourcesDir, request)
 				Ω(err).ShouldNot(HaveOccurred())
 
@@ -194,7 +194,7 @@ var _ = Describe("Out Command", func() {
 				updatedRelease := githubClient.UpdateReleaseArgsForCall(0)
 				Ω(*updatedRelease.Name).Should(Equal("v0.3.12"))
 				Ω(*updatedRelease.Body).Should(Equal("this is a great release"))
-				Ω(updatedRelease.TargetCommitish).Should(BeNil())
+				Ω(updatedRelease.TargetCommitish).Should(BeNil(), "does not set the TargetCommitish")
 			})
 		})
 

--- a/out_command_test.go
+++ b/out_command_test.go
@@ -185,7 +185,7 @@ var _ = Describe("Out Command", func() {
 		})
 
 		Context("when a commitish is not supplied", func() {
-			It("updates the existing release", func() {
+			It("does not update the target commitish", func() {
 				_, err := command.Run(sourcesDir, request)
 				Ω(err).ShouldNot(HaveOccurred())
 
@@ -194,7 +194,7 @@ var _ = Describe("Out Command", func() {
 				updatedRelease := githubClient.UpdateReleaseArgsForCall(0)
 				Ω(*updatedRelease.Name).Should(Equal("v0.3.12"))
 				Ω(*updatedRelease.Body).Should(Equal("this is a great release"))
-				Ω(updatedRelease.TargetCommitish).Should(Equal(github.String("")))
+				Ω(updatedRelease.TargetCommitish).Should(BeNil())
 			})
 		})
 


### PR DESCRIPTION
When updating an existing release without providing a commitish parameter, the resource was setting TargetCommitish to an empty string, which GitHub's API rejects with a 422 "Invalid target_commitish parameter" error.

This fix mirrors the behavior of the Body field - when commitish is not specified, TargetCommitish is now set to nil instead of an empty string, allowing GitHub to preserve the existing target commit for the release.

