### PR TITLE
Add GitHub App authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ Fetches and creates versioned GitHub releases.
         <a href="https://github.com/settings/personal-access-tokens">fine-grained access token</a> you create is only
         required to have the <code>content</code> permission. For classic access tokens, you need the
         <code>repo</code> or <code>public_repo</code> permission.
+        Mutually exclusive with <code>app_id</code>/<code>private_key</code>.
+      </td>
+    </tr>
+    <tr>
+      <td><code>app_id</code> (Optional)</td>
+      <td>
+        The ID of the GitHub App to authenticate as. Must be used together with
+        <code>private_key</code>. The resource will automatically discover the App
+        installation for the configured <code>owner</code>/<code>repository</code>.
+        Mutually exclusive with <code>access_token</code>.
+      </td>
+    </tr>
+    <tr>
+      <td><code>private_key</code> (Optional)</td>
+      <td>
+        The PEM-encoded private key of the GitHub App. Must be used together with
+        <code>app_id</code>. Mutually exclusive with <code>access_token</code>.
       </td>
     </tr>
     <tr>
@@ -146,6 +163,18 @@ Fetches and creates versioned GitHub releases.
     owner: concourse
     repository: concourse
     access_token: abcdef1234567890
+```
+
+Or using a GitHub App:
+
+``` yaml
+- name: gh-release
+  type: github-release
+  source:
+    owner: concourse
+    repository: concourse
+    app_id: ((github-app-id))
+    private_key: ((github-app-private-key))
 ```
 
 ``` yaml

--- a/github.go
+++ b/github.go
@@ -392,6 +392,7 @@ func validateAuth(source Source) error {
 
 func appInstallationClient(ctx context.Context, baseTransport http.RoundTripper, source Source) (*http.Client, func(context.Context) (string, error), error) {
 	privateKey := []byte(source.PrivateKey)
+	apiURL := normalizeURL(source.GitHubAPIURL)
 
 	// Create an app-level transport to discover the installation
 	appsTransport, err := ghinstallation.NewAppsTransport(baseTransport, int64(source.AppID), privateKey)
@@ -399,22 +400,17 @@ func appInstallationClient(ctx context.Context, baseTransport http.RoundTripper,
 		return nil, nil, fmt.Errorf("creating GitHub App transport: %w", err)
 	}
 
-	if source.GitHubAPIURL != "" {
-		apiURL := source.GitHubAPIURL
-		if !strings.HasSuffix(apiURL, "/") {
-			apiURL += "/"
-		}
+	if apiURL != "" {
 		appsTransport.BaseURL = apiURL
 	}
 
 	// Discover the installation ID for this repository
 	appClient := github.NewClient(&http.Client{Transport: appsTransport})
-	if source.GitHubAPIURL != "" {
-		apiURL := source.GitHubAPIURL
-		if !strings.HasSuffix(apiURL, "/") {
-			apiURL += "/"
+	if apiURL != "" {
+		appClient.BaseURL, err = url.Parse(apiURL)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parsing GitHub API URL: %w", err)
 		}
-		appClient.BaseURL, _ = url.Parse(apiURL)
 	}
 
 	owner := source.Owner
@@ -433,11 +429,7 @@ func appInstallationClient(ctx context.Context, baseTransport http.RoundTripper,
 		return nil, nil, fmt.Errorf("creating installation transport: %w", err)
 	}
 
-	if source.GitHubAPIURL != "" {
-		apiURL := source.GitHubAPIURL
-		if !strings.HasSuffix(apiURL, "/") {
-			apiURL += "/"
-		}
+	if apiURL != "" {
 		itr.BaseURL = apiURL
 	}
 
@@ -447,6 +439,16 @@ func appInstallationClient(ctx context.Context, baseTransport http.RoundTripper,
 	}
 
 	return httpClient, tokenFunc, nil
+}
+
+func normalizeURL(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+	if !strings.HasSuffix(rawURL, "/") {
+		return rawURL + "/"
+	}
+	return rawURL
 }
 
 func oauthClient(ctx context.Context, source Source) (*http.Client, error) {

--- a/github.go
+++ b/github.go
@@ -394,7 +394,7 @@ func appInstallationClient(ctx context.Context, baseTransport http.RoundTripper,
 	privateKey := []byte(source.PrivateKey)
 
 	// Create an app-level transport to discover the installation
-	appsTransport, err := ghinstallation.NewAppsTransport(baseTransport, source.AppID, privateKey)
+	appsTransport, err := ghinstallation.NewAppsTransport(baseTransport, int64(source.AppID), privateKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating GitHub App transport: %w", err)
 	}
@@ -428,7 +428,7 @@ func appInstallationClient(ctx context.Context, baseTransport http.RoundTripper,
 	}
 
 	// Create installation-level transport for authenticated API access
-	itr, err := ghinstallation.New(baseTransport, source.AppID, installation.GetID(), privateKey)
+	itr, err := ghinstallation.New(baseTransport, int64(source.AppID), installation.GetID(), privateKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating installation transport: %w", err)
 	}

--- a/github.go
+++ b/github.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v66/github"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
@@ -38,29 +39,54 @@ type GitHubClient struct {
 	client   *github.Client
 	clientV4 *githubv4.Client
 
-	owner       string
-	repository  string
-	accessToken string
+	owner      string
+	repository string
+	hasAuth    bool
+	tokenFunc  func(ctx context.Context) (string, error)
 }
 
 func NewGitHubClient(source Source) (*GitHubClient, error) {
-	httpClient := &http.Client{}
+	if err := validateAuth(source); err != nil {
+		return nil, err
+	}
+
+	var baseTransport http.RoundTripper = http.DefaultTransport
 	ctx := context.TODO()
 
 	if source.Insecure {
-		httpClient.Transport = &http.Transport{
+		baseTransport = &http.Transport{
 			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
-		ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: baseTransport})
 	}
 
-	if source.AccessToken != "" {
+	var httpClient *http.Client
+	var hasAuth bool
+	var tokenFunc func(ctx context.Context) (string, error)
+
+	switch {
+	case source.AccessToken != "":
 		var err error
 		httpClient, err = oauthClient(ctx, source)
 		if err != nil {
 			return nil, err
 		}
+		hasAuth = true
+		tokenFunc = func(_ context.Context) (string, error) {
+			return source.AccessToken, nil
+		}
+
+	case source.AppID != 0:
+		var err error
+		httpClient, tokenFunc, err = appInstallationClient(ctx, baseTransport, source)
+		if err != nil {
+			return nil, err
+		}
+		hasAuth = true
+
+	default:
+		httpClient = &http.Client{Transport: baseTransport}
 	}
 
 	client := github.NewClient(httpClient)
@@ -109,16 +135,17 @@ func NewGitHubClient(source Source) (*GitHubClient, error) {
 	}
 
 	return &GitHubClient{
-		client:      client,
-		clientV4:    clientV4,
-		owner:       owner,
-		repository:  source.Repository,
-		accessToken: source.AccessToken,
+		client:     client,
+		clientV4:   clientV4,
+		owner:      owner,
+		repository: source.Repository,
+		hasAuth:    hasAuth,
+		tokenFunc:  tokenFunc,
 	}, nil
 }
 
 func (g *GitHubClient) ListReleases() ([]*github.RepositoryRelease, error) {
-	if g.accessToken != "" {
+	if g.hasAuth {
 		return g.listReleasesV4()
 	}
 	opt := &github.ListOptions{PerPage: 100}
@@ -266,8 +293,12 @@ func (g *GitHubClient) DownloadReleaseAsset(asset github.ReleaseAsset) (io.ReadC
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/octet-stream")
-	if g.accessToken != "" && req.URL.Host == g.client.BaseURL.Host {
-		req.Header.Set("Authorization", "Bearer "+g.accessToken)
+	if g.hasAuth && req.URL.Host == g.client.BaseURL.Host {
+		token, err := g.tokenFunc(context.TODO())
+		if err != nil {
+			return nil, fmt.Errorf("obtaining auth token for asset download: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
 	httpClient := &http.Client{}
@@ -343,6 +374,79 @@ func (g *GitHubClient) ResolveTagToCommitSHA(tagName string) (string, error) {
 	}
 
 	return "", fmt.Errorf("could not resolve tag %q to commit: exceeded maximum tag chain depth of %d", tagName, maxDepth)
+}
+
+func validateAuth(source Source) error {
+	hasToken := source.AccessToken != ""
+	hasAppID := source.AppID != 0
+	hasKey := source.PrivateKey != ""
+
+	if hasToken && (hasAppID || hasKey) {
+		return errors.New("cannot specify both access_token and app credentials (app_id/private_key)")
+	}
+	if hasAppID != hasKey {
+		return errors.New("both app_id and private_key must be specified for GitHub App auth")
+	}
+	return nil
+}
+
+func appInstallationClient(ctx context.Context, baseTransport http.RoundTripper, source Source) (*http.Client, func(context.Context) (string, error), error) {
+	privateKey := []byte(source.PrivateKey)
+
+	// Create an app-level transport to discover the installation
+	appsTransport, err := ghinstallation.NewAppsTransport(baseTransport, source.AppID, privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating GitHub App transport: %w", err)
+	}
+
+	if source.GitHubAPIURL != "" {
+		apiURL := source.GitHubAPIURL
+		if !strings.HasSuffix(apiURL, "/") {
+			apiURL += "/"
+		}
+		appsTransport.BaseURL = apiURL
+	}
+
+	// Discover the installation ID for this repository
+	appClient := github.NewClient(&http.Client{Transport: appsTransport})
+	if source.GitHubAPIURL != "" {
+		apiURL := source.GitHubAPIURL
+		if !strings.HasSuffix(apiURL, "/") {
+			apiURL += "/"
+		}
+		appClient.BaseURL, _ = url.Parse(apiURL)
+	}
+
+	owner := source.Owner
+	if source.User != "" {
+		owner = source.User
+	}
+
+	installation, _, err := appClient.Apps.FindRepositoryInstallation(ctx, owner, source.Repository)
+	if err != nil {
+		return nil, nil, fmt.Errorf("finding GitHub App installation for %s/%s: %w", owner, source.Repository, err)
+	}
+
+	// Create installation-level transport for authenticated API access
+	itr, err := ghinstallation.New(baseTransport, source.AppID, installation.GetID(), privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating installation transport: %w", err)
+	}
+
+	if source.GitHubAPIURL != "" {
+		apiURL := source.GitHubAPIURL
+		if !strings.HasSuffix(apiURL, "/") {
+			apiURL += "/"
+		}
+		itr.BaseURL = apiURL
+	}
+
+	httpClient := &http.Client{Transport: itr}
+	tokenFunc := func(ctx context.Context) (string, error) {
+		return itr.Token(ctx)
+	}
+
+	return httpClient, tokenFunc, nil
 }
 
 func oauthClient(ctx context.Context, source Source) (*http.Client, error) {

--- a/github_test.go
+++ b/github_test.go
@@ -1,6 +1,10 @@
 package resource_test
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"net/http"
@@ -919,6 +923,140 @@ var _ = Describe("GitHub Client", func() {
 				body, err := io.ReadAll(readCloser)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(body)).To(Equal(redirectFileContents))
+			})
+		})
+	})
+
+	Describe("Auth validation", func() {
+		It("returns an error when both access_token and app credentials are set", func() {
+			_, err := NewGitHubClient(Source{
+				Owner:        "concourse",
+				Repository:   "concourse",
+				AccessToken:  "some-token",
+				AppID:        12345,
+				PrivateKey:   "some-key",
+				GitHubAPIURL: server.URL() + "/",
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot specify both access_token and app credentials"))
+		})
+
+		It("returns an error when app_id is set without private_key", func() {
+			_, err := NewGitHubClient(Source{
+				Owner:        "concourse",
+				Repository:   "concourse",
+				AppID:        12345,
+				GitHubAPIURL: server.URL() + "/",
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("both app_id and private_key must be specified"))
+		})
+
+		It("returns an error when private_key is set without app_id", func() {
+			_, err := NewGitHubClient(Source{
+				Owner:        "concourse",
+				Repository:   "concourse",
+				PrivateKey:   "some-key",
+				GitHubAPIURL: server.URL() + "/",
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("both app_id and private_key must be specified"))
+		})
+	})
+
+	Describe("GitHub App authentication", func() {
+		var testKeyPEM string
+
+		BeforeEach(func() {
+			key, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).NotTo(HaveOccurred())
+
+			testKeyPEM = string(pem.EncodeToMemory(&pem.Block{
+				Type:  "RSA PRIVATE KEY",
+				Bytes: x509.MarshalPKCS1PrivateKey(key),
+			}))
+		})
+
+		Context("when the installation is found", func() {
+			It("creates a client that uses the installation token for GraphQL", func() {
+				// Mock: discover installation for repo
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/repos/concourse/concourse/installation"),
+						ghttp.RespondWithJSONEncoded(200, map[string]any{
+							"id":     1234,
+							"app_id": 99,
+						}),
+					),
+				)
+
+				// Mock: create installation access token
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", "/app/installations/1234/access_tokens"),
+						ghttp.RespondWithJSONEncoded(201, map[string]any{
+							"token":      "ghs_testinstalltoken",
+							"expires_at": time.Now().Add(1 * time.Hour).Format(time.RFC3339),
+						}),
+					),
+				)
+
+				// Mock: the actual GraphQL call
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", "/graphql"),
+						ghttp.VerifyHeaderKV("Authorization", "token ghs_testinstalltoken"),
+						ghttp.RespondWith(200, singlePageRespEnterprise),
+					),
+				)
+
+				appClient, err := NewGitHubClient(Source{
+					Owner:        "concourse",
+					Repository:   "concourse",
+					AppID:        99,
+					PrivateKey:   testKeyPEM,
+					GitHubAPIURL: server.URL() + "/",
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				releases, err := appClient.ListReleases()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(releases).To(HaveLen(1))
+			})
+		})
+
+		Context("when the installation is not found", func() {
+			It("returns an error", func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/repos/concourse/concourse/installation"),
+						ghttp.RespondWith(404, `{"message": "Not Found"}`),
+					),
+				)
+
+				_, err := NewGitHubClient(Source{
+					Owner:        "concourse",
+					Repository:   "concourse",
+					AppID:        99,
+					PrivateKey:   testKeyPEM,
+					GitHubAPIURL: server.URL() + "/",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("finding GitHub App installation for concourse/concourse"))
+			})
+		})
+
+		Context("when the private key is invalid", func() {
+			It("returns an error", func() {
+				_, err := NewGitHubClient(Source{
+					Owner:        "concourse",
+					Repository:   "concourse",
+					AppID:        99,
+					PrivateKey:   "not-a-valid-pem-key",
+					GitHubAPIURL: server.URL() + "/",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("creating GitHub App transport"))
 			})
 		})
 	})

--- a/github_test.go
+++ b/github_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -924,6 +925,32 @@ var _ = Describe("GitHub Client", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(body)).To(Equal(redirectFileContents))
 			})
+		})
+	})
+
+	Describe("FlexInt64 unmarshaling", func() {
+		It("unmarshals app_id from a JSON number", func() {
+			input := `{"owner":"o","repository":"r","app_id":12345,"private_key":"k"}`
+			var s Source
+			err := json.Unmarshal([]byte(input), &s)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(int64(s.AppID)).To(Equal(int64(12345)))
+		})
+
+		It("unmarshals app_id from a JSON string", func() {
+			input := `{"owner":"o","repository":"r","app_id":"67890","private_key":"k"}`
+			var s Source
+			err := json.Unmarshal([]byte(input), &s)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(int64(s.AppID)).To(Equal(int64(67890)))
+		})
+
+		It("returns an error for a non-numeric string", func() {
+			input := `{"owner":"o","repository":"r","app_id":"not-a-number","private_key":"k"}`
+			var s Source
+			err := json.Unmarshal([]byte(input), &s)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not a valid integer"))
 		})
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/Masterminds/semver v1.5.0
+	github.com/bradleyfalzon/ghinstallation/v2 v2.19.0
 	github.com/cppforlife/go-semi-semantic v0.0.0-20160921010311-576b6af77ae4
 	github.com/google/go-github/v66 v66.0.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.12.2
@@ -18,7 +19,9 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/go-github/v88 v88.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/nxadm/tail v1.4.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3Q
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/bradleyfalzon/ghinstallation/v2 v2.19.0 h1:KQfD+43pRw9NUJhGycGrFr9vF1MubZacksKol1gomFI=
+github.com/bradleyfalzon/ghinstallation/v2 v2.19.0/go.mod h1:fe5ECIhCdEnxwLiBlNTxx9CP455wt42BELnlDVMvaAA=
 github.com/cppforlife/go-semi-semantic v0.0.0-20160921010311-576b6af77ae4 h1:J+ghqo7ZubTzelkjo9hntpTtP/9lUCWH9icEmAW+B+Q=
 github.com/cppforlife/go-semi-semantic v0.0.0-20160921010311-576b6af77ae4/go.mod h1:socxpf5+mELPbosI149vWpNlHK6mbfWFxSWOoSndXR8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -21,6 +23,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -36,6 +40,8 @@ github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/go-github/v66 v66.0.0 h1:ADJsaXj9UotwdgK8/iFZtv7MLc8E8WBl62WLd/D/9+M=
 github.com/google/go-github/v66 v66.0.0/go.mod h1:+4SO9Zkuyf8ytMj0csN1NR/5OTR+MfqPp8P8dVlcvY4=
+github.com/google/go-github/v88 v88.0.0 h1:dZA9IKkPK1eXZj4ypngnpRj5FwdpTv4whix2PrQMP7M=
+github.com/google/go-github/v88 v88.0.0/go.mod h1:rufTDgn2N45wjhukLTyxmvc9nilSp3mr3Rgtt6b1MPw=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 h1:EwtI+Al+DeppwYX2oXJCETMO23COyaKGP6fHVpkpWpg=

--- a/resources.go
+++ b/resources.go
@@ -1,8 +1,35 @@
 package resource
 
 import (
+	"encoding/json"
+	"fmt"
+	"strconv"
 	"time"
 )
+
+// FlexInt64 unmarshals from both JSON numbers and strings.
+// Concourse credential managers often interpolate all values as strings.
+type FlexInt64 int64
+
+func (f *FlexInt64) UnmarshalJSON(data []byte) error {
+	var n int64
+	if err := json.Unmarshal(data, &n); err == nil {
+		*f = FlexInt64(n)
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("app_id must be a number or numeric string, got: %s", string(data))
+	}
+
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return fmt.Errorf("app_id is not a valid integer: %q", s)
+	}
+	*f = FlexInt64(n)
+	return nil
+}
 
 type Source struct {
 	Owner      string `json:"owner"`
@@ -15,7 +42,7 @@ type Source struct {
 	GitHubV4APIURL   string `json:"github_v4_api_url"`
 	GitHubUploadsURL string `json:"github_uploads_url"`
 	AccessToken string `json:"access_token"`
-	AppID       int64  `json:"app_id"`
+	AppID       FlexInt64 `json:"app_id"`
 	PrivateKey  string `json:"private_key"`
 	Drafts           bool   `json:"drafts"`
 	PreRelease       bool   `json:"pre_release"`

--- a/resources.go
+++ b/resources.go
@@ -14,7 +14,9 @@ type Source struct {
 	GitHubAPIURL     string `json:"github_api_url"`
 	GitHubV4APIURL   string `json:"github_v4_api_url"`
 	GitHubUploadsURL string `json:"github_uploads_url"`
-	AccessToken      string `json:"access_token"`
+	AccessToken string `json:"access_token"`
+	AppID       int64  `json:"app_id"`
+	PrivateKey  string `json:"private_key"`
 	Drafts           bool   `json:"drafts"`
 	PreRelease       bool   `json:"pre_release"`
 	Release          bool   `json:"release"`


### PR DESCRIPTION
## Motivation

Some organizations forbid the use of personal access tokens, which makes this resource unusable in those environments. This PR adds GitHub App authentication as an alternative to personal access tokens.

## Changes

Adds `app_id` and `private_key` as source configuration options. When provided, the resource authenticates as a GitHub App installation:

1. Creates an app-level JWT from the provided credentials
2. Auto-discovers the installation ID for the configured `owner`/`repository`
3. Obtains an installation access token (auto-refreshed by the transport)

### Example configuration

```yaml
resources:
- name: my-release
  type: github-release
  source:
    owner: my-org
    repository: my-repo
    app_id: ((github-app-id))
    private_key: ((github-app-private-key))
```

### Notes

- `app_id` accepts both numeric and string values (credential managers like Vault/CredHub interpolate everything as strings)
- Fully supports GitHub Enterprise (custom API URLs)
- Mutually exclusive with `access_token` - providing both is a validation error
- All existing behavior is unchanged when using `access_token`

Fixes https://github.com/concourse/github-release-resource/issues/124