### PR TITLE
bump go-github to v88

### DIFF
--- a/check_command.go
+++ b/check_command.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/cppforlife/go-semi-semantic/version"
-	"github.com/google/go-github/v66/github"
+	"github.com/google/go-github/v88/github"
 )
 
 type CheckCommand struct {

--- a/check_command_test.go
+++ b/check_command_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/google/go-github/v88/github"
 
 	resource "github.com/concourse/github-release-resource"
 	"github.com/concourse/github-release-resource/fakes"

--- a/fakes/fake_git_hub.go
+++ b/fakes/fake_git_hub.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	resource "github.com/concourse/github-release-resource"
-	"github.com/google/go-github/v66/github"
+	"github.com/google/go-github/v88/github"
 )
 
 type FakeGitHub struct {

--- a/github.go
+++ b/github.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/google/go-github/v66/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )
@@ -65,6 +65,7 @@ func NewGitHubClient(source Source) (*GitHubClient, error) {
 	var hasAuth bool
 	var tokenFunc func(ctx context.Context) (string, error)
 
+	var opts []github.ClientOptionsFunc
 	switch {
 	case source.AccessToken != "":
 		var err error
@@ -89,44 +90,38 @@ func NewGitHubClient(source Source) (*GitHubClient, error) {
 		httpClient = &http.Client{Transport: baseTransport}
 	}
 
-	client := github.NewClient(httpClient)
+	opts = append(opts, github.WithHTTPClient(httpClient))
 
 	clientV4 := githubv4.NewClient(httpClient)
 
+	var baseURL, uploadURL *string
 	if source.GitHubAPIURL != "" {
-		var err error
-		if !strings.HasSuffix(source.GitHubAPIURL, "/") {
-			source.GitHubAPIURL += "/"
-		}
-		client.BaseURL, err = url.Parse(source.GitHubAPIURL)
-		if err != nil {
-			return nil, err
-		}
-
-		client.UploadURL, err = url.Parse(source.GitHubAPIURL)
-		if err != nil {
-			return nil, err
-		}
+		b := normalizeURL(source.GitHubAPIURL)
+		baseURL = &b
+		uploadURL = &b
 
 		var v4URL string
-		if s, found := strings.CutSuffix(source.GitHubAPIURL, "/v3/"); found {
-			v4URL = s + "/graphql"
-		} else {
-			v4URL = source.GitHubAPIURL + "graphql"
-		}
+		v4URL, _ = strings.CutSuffix(source.GitHubAPIURL, "/v3/")
+		v4URL, _ = strings.CutSuffix(v4URL, "/v3")
+
+		v4URL = normalizeURL(v4URL) + "graphql"
 		clientV4 = githubv4.NewEnterpriseClient(v4URL, httpClient)
 	}
+
+	if source.GitHubUploadsURL != "" {
+		u := normalizeURL(source.GitHubUploadsURL)
+		uploadURL = &u
+	}
+
+	opts = append(opts, github.WithURLs(baseURL, uploadURL))
 
 	if source.GitHubV4APIURL != "" {
 		clientV4 = githubv4.NewEnterpriseClient(source.GitHubV4APIURL, httpClient)
 	}
 
-	if source.GitHubUploadsURL != "" {
-		var err error
-		client.UploadURL, err = url.Parse(source.GitHubUploadsURL)
-		if err != nil {
-			return nil, err
-		}
+	client, err := github.NewClient(opts...)
+	if err != nil {
+		return nil, err
 	}
 
 	owner := source.Owner
@@ -288,12 +283,17 @@ func (g *GitHubClient) DownloadReleaseAsset(asset github.ReleaseAsset) (io.ReadC
 		return bodyReader, err
 	}
 
-	req, err := g.client.NewRequest("GET", redirectURL, nil)
+	req, err := g.client.NewRequest(context.TODO(), "GET", redirectURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/octet-stream")
-	if g.hasAuth && req.URL.Host == g.client.BaseURL.Host {
+	baseURL, err := url.Parse(g.client.BaseURL())
+	if err != nil {
+		return nil, err
+	}
+
+	if g.hasAuth && req.URL.Host == baseURL.Host {
 		token, err := g.tokenFunc(context.TODO())
 		if err != nil {
 			return nil, fmt.Errorf("obtaining auth token for asset download: %w", err)
@@ -393,24 +393,24 @@ func validateAuth(source Source) error {
 func appInstallationClient(ctx context.Context, baseTransport http.RoundTripper, source Source) (*http.Client, func(context.Context) (string, error), error) {
 	privateKey := []byte(source.PrivateKey)
 	apiURL := normalizeURL(source.GitHubAPIURL)
+	var opts []github.ClientOptionsFunc
 
 	// Create an app-level transport to discover the installation
-	appsTransport, err := ghinstallation.NewAppsTransport(baseTransport, int64(source.AppID), privateKey)
+	appsTransport, err := ghinstallation.NewAppsTransport(baseTransport, source.AppID.Int64(), privateKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating GitHub App transport: %w", err)
 	}
+	opts = append(opts, github.WithHTTPClient(&http.Client{Transport: appsTransport}))
 
 	if apiURL != "" {
 		appsTransport.BaseURL = apiURL
+		opts = append(opts, github.WithURLs(&apiURL, nil))
 	}
 
 	// Discover the installation ID for this repository
-	appClient := github.NewClient(&http.Client{Transport: appsTransport})
-	if apiURL != "" {
-		appClient.BaseURL, err = url.Parse(apiURL)
-		if err != nil {
-			return nil, nil, fmt.Errorf("parsing GitHub API URL: %w", err)
-		}
+	appClient, err := github.NewClient(opts...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating client for app installation ID discovery: %w", err)
 	}
 
 	owner := source.Owner
@@ -418,13 +418,13 @@ func appInstallationClient(ctx context.Context, baseTransport http.RoundTripper,
 		owner = source.User
 	}
 
-	installation, _, err := appClient.Apps.FindRepositoryInstallation(ctx, owner, source.Repository)
+	installation, _, err := appClient.Apps.GetRepositoryInstallation(ctx, owner, source.Repository)
 	if err != nil {
 		return nil, nil, fmt.Errorf("finding GitHub App installation for %s/%s: %w", owner, source.Repository, err)
 	}
 
 	// Create installation-level transport for authenticated API access
-	itr, err := ghinstallation.New(baseTransport, int64(source.AppID), installation.GetID(), privateKey)
+	itr, err := ghinstallation.New(baseTransport, source.AppID.Int64(), installation.GetID(), privateKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating installation transport: %w", err)
 	}
@@ -433,12 +433,7 @@ func appInstallationClient(ctx context.Context, baseTransport http.RoundTripper,
 		itr.BaseURL = apiURL
 	}
 
-	httpClient := &http.Client{Transport: itr}
-	tokenFunc := func(ctx context.Context) (string, error) {
-		return itr.Token(ctx)
-	}
-
-	return httpClient, tokenFunc, nil
+	return &http.Client{Transport: itr}, itr.Token, nil
 }
 
 func normalizeURL(rawURL string) string {

--- a/github_graphql.go
+++ b/github_graphql.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/shurcooL/githubv4"
 )
 

--- a/github_test.go
+++ b/github_test.go
@@ -17,7 +17,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/onsi/gomega/ghttp"
 )
 
@@ -169,41 +169,31 @@ var _ = Describe("GitHub Client", func() {
 				Repository: "concourse",
 			}
 		})
-		Context("given only the v3 API endpoint", func() {
-			It("should replace v3 with graphql", func() {
-				server.AppendHandlers(
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("POST", "/api/graphql"),
-						ghttp.RespondWith(200, singlePageRespEnterprise),
-					),
-				)
+		Context("deriving the GraphQL (v4) endpoint from the v3 API URL", func() {
+			DescribeTable("appends graphql, stripping any /v3 suffix first",
+				func(apiPath, expectedGraphQLPath string) {
+					server.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("POST", expectedGraphQLPath),
+							ghttp.RespondWith(200, singlePageRespEnterprise),
+						),
+					)
 
-				source.GitHubAPIURL = server.URL() + "/api/v3"
-				//setting the access token is how we ensure the v4 client is used
-				source.AccessToken = "abc123"
-				client, err = NewGitHubClient(source)
-				Ω(err).ShouldNot(HaveOccurred())
+					source.GitHubAPIURL = server.URL() + apiPath
+					//setting the access token is how we ensure the v4 client is used
+					source.AccessToken = "abc123"
+					client, err = NewGitHubClient(source)
+					Expect(err).ShouldNot(HaveOccurred())
 
-				_, err := client.ListReleases()
-				Ω(err).ShouldNot(HaveOccurred())
-			})
-			It("should always append graphql", func() {
-				server.AppendHandlers(
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("POST", "/api/graphql"),
-						ghttp.RespondWith(200, singlePageRespEnterprise),
-					),
-				)
-
-				source.GitHubAPIURL = server.URL() + "/api/"
-				//setting the access token is how we ensure the v4 client is used
-				source.AccessToken = "abc123"
-				client, err = NewGitHubClient(source)
-				Ω(err).ShouldNot(HaveOccurred())
-
-				_, err := client.ListReleases()
-				Ω(err).ShouldNot(HaveOccurred())
-			})
+					_, err := client.ListReleases()
+					Expect(err).ShouldNot(HaveOccurred())
+				},
+				Entry("strips a /v3/ suffix", "/api/v3/", "/api/graphql"),
+				Entry("strips a /v3 suffix without a trailing slash", "/api/v3", "/api/graphql"),
+				Entry("appends graphql when the path already ends in a slash", "/api/", "/api/graphql"),
+				Entry("appends graphql when the path has no trailing slash", "/api", "/api/graphql"),
+				Entry("handles a bare host with a trailing slash", "/", "/graphql"),
+			)
 		})
 	})
 
@@ -772,7 +762,7 @@ var _ = Describe("GitHub Client", func() {
 			const redirectPath = "/the/redirect/path"
 
 			BeforeEach(func() {
-				appendGetHandler(server, assetPath, 307, "", true, locationHeader(redirectPath))
+				appendGetHandler(server, assetPath, http.StatusFound, "", true, locationHeader(redirectPath))
 			})
 
 			Context("when the redirect succeeds", func() {
@@ -802,7 +792,7 @@ var _ = Describe("GitHub Client", func() {
 				)
 
 				BeforeEach(func() {
-					appendGetHandler(server, redirectPath, 307, "", true, locationHeader("/somewhere-else"))
+					appendGetHandler(server, redirectPath, http.StatusFound, "", true, locationHeader("/somewhere-else"))
 					appendGetHandler(server, "/somewhere-else", 200, redirectFileContents, true)
 				})
 
@@ -830,7 +820,7 @@ var _ = Describe("GitHub Client", func() {
 					Expect(err).NotTo(HaveOccurred())
 					externalUrl := fmt.Sprintf("http://localhost:%s", u.Port())
 
-					appendGetHandler(server, redirectPath, 307, "", true, locationHeader(externalUrl+"/somewhere-else"))
+					appendGetHandler(server, redirectPath, http.StatusFound, "", true, locationHeader(externalUrl+"/somewhere-else"))
 					appendGetHandler(externalServer, "/somewhere-else", 200, redirectFileContents, false)
 				})
 
@@ -912,7 +902,7 @@ var _ = Describe("GitHub Client", func() {
 			BeforeEach(func() {
 				externalServer = ghttp.NewServer()
 
-				appendGetHandler(server, assetPath, 307, "", true, locationHeader(externalServer.URL()+"/somewhere-else"))
+				appendGetHandler(server, assetPath, http.StatusFound, "", true, locationHeader(externalServer.URL()+"/somewhere-else"))
 				appendGetHandler(externalServer, "/somewhere-else", 200, redirectFileContents, false)
 			})
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/bradleyfalzon/ghinstallation/v2 v2.19.0
 	github.com/cppforlife/go-semi-semantic v0.0.0-20160921010311-576b6af77ae4
-	github.com/google/go-github/v66 v66.0.0
+	github.com/google/go-github/v88 v88.0.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.12.2
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
 	github.com/onsi/ginkgo/v2 v2.28.3
@@ -21,7 +21,6 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/go-github/v88 v88.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/nxadm/tail v1.4.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,6 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v66 v66.0.0 h1:ADJsaXj9UotwdgK8/iFZtv7MLc8E8WBl62WLd/D/9+M=
-github.com/google/go-github/v66 v66.0.0/go.mod h1:+4SO9Zkuyf8ytMj0csN1NR/5OTR+MfqPp8P8dVlcvY4=
 github.com/google/go-github/v88 v88.0.0 h1:dZA9IKkPK1eXZj4ypngnpRj5FwdpTv4whix2PrQMP7M=
 github.com/google/go-github/v88 v88.0.0/go.mod h1:rufTDgn2N45wjhukLTyxmvc9nilSp3mr3Rgtt6b1MPw=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=

--- a/in_command.go
+++ b/in_command.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/google/go-github/v88/github"
 )
 
 type InCommand struct {

--- a/in_command_test.go
+++ b/in_command_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/google/go-github/v88/github"
 
 	resource "github.com/concourse/github-release-resource"
 	"github.com/concourse/github-release-resource/fakes"

--- a/metadata.go
+++ b/metadata.go
@@ -1,6 +1,6 @@
 package resource
 
-import "github.com/google/go-github/v66/github"
+import "github.com/google/go-github/v88/github"
 
 func metadataFromRelease(release *github.RepositoryRelease, commitSHA string) []MetadataPair {
 	metadata := []MetadataPair{}

--- a/out_command.go
+++ b/out_command.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/google/go-github/v88/github"
 )
 
 type OutCommand struct {

--- a/out_command_test.go
+++ b/out_command_test.go
@@ -12,7 +12,7 @@ import (
 	resource "github.com/concourse/github-release-resource"
 	"github.com/concourse/github-release-resource/fakes"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/google/go-github/v88/github"
 )
 
 func file(path, contents string) {

--- a/resource_suite_test.go
+++ b/resource_suite_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	resource "github.com/concourse/github-release-resource"
-	"github.com/google/go-github/v66/github"
+	"github.com/google/go-github/v88/github"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/resources.go
+++ b/resources.go
@@ -31,6 +31,10 @@ func (f *FlexInt64) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (f FlexInt64) Int64() int64 {
+	return int64(f)
+}
+
 type Source struct {
 	Owner      string `json:"owner"`
 	Repository string `json:"repository"`
@@ -38,17 +42,17 @@ type Source struct {
 	// Deprecated; use Owner instead
 	User string `json:"user"`
 
-	GitHubAPIURL     string `json:"github_api_url"`
-	GitHubV4APIURL   string `json:"github_v4_api_url"`
-	GitHubUploadsURL string `json:"github_uploads_url"`
-	AccessToken string `json:"access_token"`
-	AppID       FlexInt64 `json:"app_id"`
-	PrivateKey  string `json:"private_key"`
-	Drafts           bool   `json:"drafts"`
-	PreRelease       bool   `json:"pre_release"`
-	Release          bool   `json:"release"`
-	Insecure         bool   `json:"insecure"`
-	AssetDir         bool   `json:"asset_dir"`
+	GitHubAPIURL     string    `json:"github_api_url"`
+	GitHubV4APIURL   string    `json:"github_v4_api_url"`
+	GitHubUploadsURL string    `json:"github_uploads_url"`
+	AccessToken      string    `json:"access_token"`
+	AppID            FlexInt64 `json:"app_id"`
+	PrivateKey       string    `json:"private_key"`
+	Drafts           bool      `json:"drafts"`
+	PreRelease       bool      `json:"pre_release"`
+	Release          bool      `json:"release"`
+	Insecure         bool      `json:"insecure"`
+	AssetDir         bool      `json:"asset_dir"`
 
 	TagFilter        string `json:"tag_filter"`
 	OrderBy          string `json:"order_by"`

--- a/versions.go
+++ b/versions.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/google/go-github/v88/github"
 )
 
 var defaultTagFilter = "^v?([^v].*)"


### PR DESCRIPTION
- Fixed redirect tests to return HTTP 302, which is what github.com actually returns. These tests started failing because the updated github client doesn't follow 307's
- Fixed a bug when creating the graphql URL and it had a `/v3` suffix